### PR TITLE
Refactor #200 게시판 작성 request 변경 및 게시판 수정 api 분리

### DIFF
--- a/src/main/java/leets/weeth/domain/board/application/dto/PostDTO.java
+++ b/src/main/java/leets/weeth/domain/board/application/dto/PostDTO.java
@@ -31,6 +31,7 @@ public class PostDTO {
     public record SaveEducation(
             @NotNull String title,
             @NotNull String content,
+            @NotNull Integer cardinalNumber,
             @NotNull List<Part> parts,
             @Valid List<@NotNull FileSaveRequest> files
     ){}

--- a/src/main/java/leets/weeth/domain/board/application/dto/PostDTO.java
+++ b/src/main/java/leets/weeth/domain/board/application/dto/PostDTO.java
@@ -20,8 +20,10 @@ public class PostDTO {
             @NotNull String title,
             @NotNull String content,
             @NotNull Category category,
-            @NotNull String studyName,
-            @NotNull int week,
+            String studyName,
+            int week,
+            @NotNull Part part,
+            @NotNull Integer cardinalNumber,
             @Valid List<@NotNull FileSaveRequest> files
     ){}
 

--- a/src/main/java/leets/weeth/domain/board/application/dto/PostDTO.java
+++ b/src/main/java/leets/weeth/domain/board/application/dto/PostDTO.java
@@ -64,7 +64,12 @@ public class PostDTO {
             Role role,
             String title,
             String content,
-            LocalDateTime time,//modifiedAt
+            String studyName,
+            Integer week,
+            Integer cardinalNumber,
+            Part part,
+            List<Part> parts,
+            LocalDateTime time,
             Integer commentCount,
             List<CommentDTO.Response> comments,
             List<FileResponse> fileUrls

--- a/src/main/java/leets/weeth/domain/board/application/dto/PostDTO.java
+++ b/src/main/java/leets/weeth/domain/board/application/dto/PostDTO.java
@@ -31,16 +31,29 @@ public class PostDTO {
     public record SaveEducation(
             @NotNull String title,
             @NotNull String content,
-            @NotNull Integer cardinalNumber,
             @NotNull List<Part> parts,
+            @NotNull Integer cardinalNumber,
             @Valid List<@NotNull FileSaveRequest> files
     ){}
 
     @Builder
     public record Update(
-            @NotNull String title,
-            @NotNull String content,
-            @Valid List<@NotNull FileSaveRequest> files
+            String title,
+            String content,
+            String studyName,
+            Integer week,
+            Part part,
+            Integer cardinalNumber,
+            @Valid List<FileSaveRequest> files
+    ){}
+
+    @Builder
+    public record UpdateEducation(
+            String title,
+            String content,
+            List<Part> parts,
+            Integer cardinalNumber,
+            @Valid List<FileSaveRequest> files
     ){}
 
     @Builder

--- a/src/main/java/leets/weeth/domain/board/application/mapper/PostMapper.java
+++ b/src/main/java/leets/weeth/domain/board/application/mapper/PostMapper.java
@@ -22,11 +22,11 @@ public interface PostMapper {
             @Mapping(target = "createdAt", ignore = true),
             @Mapping(target = "modifiedAt", ignore = true),
             @Mapping(target = "user", source = "user"),
-            @Mapping(target = "part", expression = "java(user.getUserPart())"),
-            @Mapping(target = "parts", expression = "java(List.of(user.getUserPart()))"),
-            @Mapping(target = "cardinalNumber", expression = "java(latest.getCardinalNumber())")
+            @Mapping(target = "part", source = "dto.part"),
+            @Mapping(target = "parts", expression = "java(List.of(dto.part()))"),
+            @Mapping(target = "cardinalNumber", source = "dto.cardinalNumber")
     })
-    Post fromPostDto(PostDTO.Save dto, User user, Cardinal latest);
+    Post fromPostDto(PostDTO.Save dto, User user);
 
     @Mapping(target = "id", ignore = true)
     @Mapping(target = "createdAt", ignore = true)

--- a/src/main/java/leets/weeth/domain/board/application/mapper/PostMapper.java
+++ b/src/main/java/leets/weeth/domain/board/application/mapper/PostMapper.java
@@ -6,7 +6,6 @@ import leets.weeth.domain.board.domain.entity.Post;
 import leets.weeth.domain.comment.application.dto.CommentDTO;
 import leets.weeth.domain.comment.application.mapper.CommentMapper;
 import leets.weeth.domain.file.application.dto.response.FileResponse;
-import leets.weeth.domain.user.domain.entity.Cardinal;
 import leets.weeth.domain.user.domain.entity.User;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
@@ -34,9 +33,9 @@ public interface PostMapper {
     @Mapping(target = "user", source = "user")
     @Mapping(target = "part", ignore = true)
     @Mapping(target = "parts", source = "dto.parts")
-    @Mapping(target = "cardinalNumber", expression = "java(latest.getCardinalNumber())")
+    @Mapping(target = "cardinalNumber", source = "dto.cardinalNumber")
     @Mapping(target = "category", constant = "Education")
-    Post fromEducationDto(PostDTO.SaveEducation dto, User user, Cardinal latest);
+    Post fromEducationDto(PostDTO.SaveEducation dto, User user);
 
     @Mappings({
             @Mapping(target = "name", source = "post.user.name"),

--- a/src/main/java/leets/weeth/domain/board/application/usecase/PostUseCaseImpl.java
+++ b/src/main/java/leets/weeth/domain/board/application/usecase/PostUseCaseImpl.java
@@ -73,8 +73,8 @@ public class PostUseCaseImpl implements PostUsecase {
             throw new CategoryAccessDeniedException();
         }
 
-        Cardinal latest = cardinalGetService.findLatestInProgress();
-        Post post = mapper.fromPostDto(request, user, latest);
+        cardinalGetService.findByUserSide(request.cardinalNumber());
+        Post post = mapper.fromPostDto(request, user);
         postSaveService.save(post);
 
         List<File> files = fileMapper.toFileList(request.files(), post);

--- a/src/main/java/leets/weeth/domain/board/application/usecase/PostUseCaseImpl.java
+++ b/src/main/java/leets/weeth/domain/board/application/usecase/PostUseCaseImpl.java
@@ -1,7 +1,6 @@
 package leets.weeth.domain.board.application.usecase;
 
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -27,7 +26,6 @@ import leets.weeth.domain.file.domain.service.FileDeleteService;
 import leets.weeth.domain.file.domain.service.FileGetService;
 import leets.weeth.domain.file.domain.service.FileSaveService;
 import leets.weeth.domain.user.application.exception.UserNotMatchException;
-import leets.weeth.domain.user.domain.entity.Cardinal;
 import leets.weeth.domain.user.domain.entity.User;
 import leets.weeth.domain.user.domain.entity.enums.Role;
 import leets.weeth.domain.user.domain.service.CardinalGetService;
@@ -86,11 +84,7 @@ public class PostUseCaseImpl implements PostUsecase {
     public void saveEducation(PostDTO.SaveEducation request, Long userId) {
         User user = userGetService.find(userId);
 
-        Cardinal latest = cardinalGetService.findInProgress().stream()
-                .max(Comparator.comparing(Cardinal::getCardinalNumber))
-                .orElseThrow();
-
-        Post post = mapper.fromEducationDto(request, user, latest);
+        Post post = mapper.fromEducationDto(request, user);
 
         postSaveService.save(post);
 

--- a/src/main/java/leets/weeth/domain/board/application/usecase/PostUseCaseImpl.java
+++ b/src/main/java/leets/weeth/domain/board/application/usecase/PostUseCaseImpl.java
@@ -172,13 +172,31 @@ public class PostUseCaseImpl implements PostUsecase {
     public void update(Long postId, PostDTO.Update dto, Long userId) {
         Post post = validateOwner(postId, userId);
 
-        List<File> fileList = getFiles(postId);
-        fileDeleteService.delete(fileList);
+        if (dto.files() != null) {
+            List<File> fileList = getFiles(postId);
+            fileDeleteService.delete(fileList);
 
-        List<File> files = fileMapper.toFileList(dto.files(), post);
-        fileSaveService.save(files);
+            List<File> files = fileMapper.toFileList(dto.files(), post);
+            fileSaveService.save(files);
+        }
 
         postUpdateService.update(post, dto);
+    }
+
+    @Override
+    @Transactional
+    public void updateEducation(Long postId, PostDTO.UpdateEducation dto, Long userId) {
+        Post post = validateOwner(postId, userId);
+
+        if (dto.files() != null) {
+            List<File> fileList = getFiles(postId);
+            fileDeleteService.delete(fileList);
+
+            List<File> files = fileMapper.toFileList(dto.files(), post);
+            fileSaveService.save(files);
+        }
+
+        postUpdateService.updateEducation(post, dto);
     }
 
     @Override

--- a/src/main/java/leets/weeth/domain/board/application/usecase/PostUsecase.java
+++ b/src/main/java/leets/weeth/domain/board/application/usecase/PostUsecase.java
@@ -22,6 +22,8 @@ public interface PostUsecase {
 
     void update(Long postId, PostDTO.Update dto, Long userId) throws UserNotMatchException;
 
+    void updateEducation(Long postId, PostDTO.UpdateEducation dto, Long userId) throws UserNotMatchException;
+
     void delete(Long postId, Long userId) throws UserNotMatchException;
 
     Slice<PostDTO.ResponseAll> searchPost(String keyword, int pageNumber, int pageSize);

--- a/src/main/java/leets/weeth/domain/board/domain/entity/Board.java
+++ b/src/main/java/leets/weeth/domain/board/domain/entity/Board.java
@@ -68,7 +68,12 @@ public class Board extends BaseEntity {
     }
 
     public void updateUpperClass(PostDTO.Update dto) {
-        this.title = dto.title();
-        this.content = dto.content();
+        if (dto.title() != null) this.title = dto.title();
+        if (dto.content() != null) this.content = dto.content();
+    }
+
+    public void updateUpperClass(PostDTO.UpdateEducation dto) {
+        if (dto.title() != null) this.title = dto.title();
+        if (dto.content() != null) this.content = dto.content();
     }
 }

--- a/src/main/java/leets/weeth/domain/board/domain/entity/Post.java
+++ b/src/main/java/leets/weeth/domain/board/domain/entity/Post.java
@@ -7,6 +7,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.OneToMany;
+import java.util.ArrayList;
 import java.util.List;
 import leets.weeth.domain.board.application.dto.PostDTO;
 import leets.weeth.domain.board.domain.converter.PartListConverter;
@@ -38,7 +39,7 @@ public class Post extends Board {
 
     @Column(nullable = false, columnDefinition = "varchar(255)")
     @Convert(converter = PartListConverter.class)
-    private List<Part> parts;
+    private List<Part> parts = new ArrayList<>();
 
     @Enumerated(EnumType.STRING)
     private Category category;
@@ -57,5 +58,19 @@ public class Post extends Board {
 
     public void update(PostDTO.Update dto) {
         this.updateUpperClass(dto);
+        if (dto.studyName() != null)  this.studyName = dto.studyName();
+        if (dto.week() != null)       this.week = dto.week();
+        if (dto.part() != null) {
+            this.part = dto.part();
+            this.parts = List.of(dto.part());
+        }
+        if (dto.cardinalNumber() != null) this.cardinalNumber = dto.cardinalNumber();
+    }
+
+    public void updateEducation(PostDTO.UpdateEducation dto) {
+        this.updateUpperClass(dto);
+        this.part = null;
+        if (dto.parts() != null) this.parts = dto.parts();
+        if (dto.cardinalNumber() != null) this.cardinalNumber = dto.cardinalNumber();
     }
 }

--- a/src/main/java/leets/weeth/domain/board/domain/service/PostUpdateService.java
+++ b/src/main/java/leets/weeth/domain/board/domain/service/PostUpdateService.java
@@ -1,15 +1,9 @@
 package leets.weeth.domain.board.domain.service;
 
-import jakarta.transaction.Transactional;
 import leets.weeth.domain.board.application.dto.PostDTO;
-import leets.weeth.domain.board.application.mapper.PostMapper;
 import leets.weeth.domain.board.domain.entity.Post;
-import leets.weeth.domain.board.domain.repository.PostRepository;
-import leets.weeth.domain.user.domain.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -19,4 +13,7 @@ public class PostUpdateService {
         post.update(dto);
     }
 
+    public void updateEducation(Post post, PostDTO.UpdateEducation dto){
+        post.updateEducation(dto);
+    }
 }

--- a/src/main/java/leets/weeth/domain/board/presentation/EducationAdminController.java
+++ b/src/main/java/leets/weeth/domain/board/presentation/EducationAdminController.java
@@ -35,7 +35,7 @@ public class EducationAdminController {
         return CommonResponse.createSuccess(POST_CREATED_SUCCESS.getMessage());
     }
 
-    @PatchMapping(value = "/{boardId}/education")
+    @PatchMapping(value = "/{boardId}")
     @Operation(summary="교육자료 게시글 수정")
     public CommonResponse<String> update(@PathVariable Long boardId,
                                          @RequestBody @Valid PostDTO.UpdateEducation dto,

--- a/src/main/java/leets/weeth/domain/board/presentation/EducationAdminController.java
+++ b/src/main/java/leets/weeth/domain/board/presentation/EducationAdminController.java
@@ -1,5 +1,6 @@
 package leets.weeth.domain.board.presentation;
 
+import static leets.weeth.domain.board.presentation.ResponseMessage.EDUCATION_UPDATED_SUCCESS;
 import static leets.weeth.domain.board.presentation.ResponseMessage.POST_CREATED_SUCCESS;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -8,9 +9,12 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import leets.weeth.domain.board.application.dto.PostDTO;
 import leets.weeth.domain.board.application.usecase.PostUsecase;
+import leets.weeth.domain.user.application.exception.UserNotMatchException;
 import leets.weeth.global.auth.annotation.CurrentUser;
 import leets.weeth.global.common.response.CommonResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -29,5 +33,14 @@ public class EducationAdminController {
         postUsecase.saveEducation(dto, userId);
 
         return CommonResponse.createSuccess(POST_CREATED_SUCCESS.getMessage());
+    }
+
+    @PatchMapping(value = "/{boardId}/education")
+    @Operation(summary="교육자료 게시글 수정")
+    public CommonResponse<String> update(@PathVariable Long boardId,
+                                         @RequestBody @Valid PostDTO.UpdateEducation dto,
+                                         @Parameter(hidden = true) @CurrentUser Long userId) throws UserNotMatchException {
+        postUsecase.updateEducation(boardId, dto, userId);
+        return CommonResponse.createSuccess(EDUCATION_UPDATED_SUCCESS.getMessage());
     }
 }

--- a/src/main/java/leets/weeth/domain/board/presentation/PostController.java
+++ b/src/main/java/leets/weeth/domain/board/presentation/PostController.java
@@ -82,8 +82,8 @@ public class PostController {
         return CommonResponse.createSuccess(POST_FIND_BY_ID_SUCCESS.getMessage(),postUsecase.searchPost(keyword, pageNumber, pageSize));
     }
 
-    @PatchMapping(value = "/{boardId}")
-    @Operation(summary="특정 게시글 수정")
+    @PatchMapping(value = "/{boardId}/part")
+    @Operation(summary="파트 게시글 수정")
     public CommonResponse<String> update(@PathVariable Long boardId,
                                          @RequestBody @Valid PostDTO.Update dto,
                                          @Parameter(hidden = true) @CurrentUser Long userId) throws UserNotMatchException {

--- a/src/main/java/leets/weeth/domain/board/presentation/ResponseMessage.java
+++ b/src/main/java/leets/weeth/domain/board/presentation/ResponseMessage.java
@@ -14,12 +14,14 @@ public enum ResponseMessage {
     NOTICE_FIND_BY_ID_SUCCESS("공지사항이 성공적으로 조회되었습니다."),
     //PostController 관련
     POST_CREATED_SUCCESS("게시글이 성공적으로 생성되었습니다."),
-    POST_UPDATED_SUCCESS("게시글이 성공적으로 수정되었습니다."),
+    POST_UPDATED_SUCCESS("파트 게시글이 성공적으로 수정되었습니다."),
     POST_DELETED_SUCCESS("게시글이 성공적으로 삭제되었습니다."),
     POST_FIND_ALL_SUCCESS("게시글 목록이 성공적으로 조회되었습니다."),
     POST_PART_FIND_ALL_SUCCESS("파트별 게시글 목록이 성공적으로 조회되었습니다."),
     POST_EDU_FIND_SUCCESS("교육 게시글 목록이 성공적으로 조회되었습니다."),
-    POST_FIND_BY_ID_SUCCESS("게시글이 성공적으로 조회되었습니다.");
+    POST_FIND_BY_ID_SUCCESS("게시글이 성공적으로 조회되었습니다."),
+
+    EDUCATION_UPDATED_SUCCESS("교육자료가 성공적으로 수정되었습니다.");
 
     private final String message;
 }


### PR DESCRIPTION
## PR 내용

게시판 디자인이 변경됨에 따라서, 새로 바뀐 뷰에 맞춰서 아래 내용들을 수정했습니다

<br>

## PR 세부사항

파트 게시판 작성 `request` 변경
- [x] 파트 게시판 작성시 스터디 이름, 주차 선택적으로 입력받도록 변경
- [x] 기수 + 파트 명시적으로 입력받도록 변경 

교육자료 게시판 작성 `request` 변경
- [x] 마찬가지로 기수 + 파트 리스트 명시적으로 입력받는 방식으로 변경된 뷰에 맞춰서 작업 예정

게시판 수정 API 분리

파트 게시판 수정 API 
제목 + 내용 + 파일에 추가 필드들 반영 (스터디 이름, 주차, 기수, 파트)

4. 교육자료 수정 API 추가 (분리 이유 -> 파트게시판과 다르게 리스트로 파트를 입력받기때문)
제목 + 내용 + 파일 (기수, 파트 리스트)

게시판 상세조회 응답 dto 수정
- [x] 제목 + 내용 + 파일에 추가 필드들 반영 (스터디이름,주차수, 기수, 파트, 파트 리스트)


<br>

## 관련 스크린샷

<br>

## 주의사항

게시글 수정방식이 명시적으로 모든 필드들 보내주기보다는, 수정이 필요한 부분만 입력받는 로직으로 변경되었으니 꼼꼼하게 봐주시면 감사하겠습니다 🙇🏻‍♂️

<br>

## 체크 리스트

- [x] 리뷰어 설정
- [x] Assignee 설정
- [x] Label 설정
- [x] 제목 양식 맞췄나요? (ex. #0 Feat: 기능 추가)
- [x] 변경 사항에 대한 테스트