### PR TITLE
Fix #208 어드민으로 교육자료 조회시 분기처리 로직 기수 반영하도록 수정

### DIFF
--- a/src/main/java/leets/weeth/domain/board/application/usecase/PostUseCaseImpl.java
+++ b/src/main/java/leets/weeth/domain/board/application/usecase/PostUseCaseImpl.java
@@ -131,7 +131,7 @@ public class PostUseCaseImpl implements PostUsecase {
 
         if (user.hasRole(Role.ADMIN)) {
 
-            return postFindService.findByCategory(part, Category.Education, pageNumber, pageSize)
+            return postFindService.findByCategory(part, Category.Education, cardinalNumber, pageNumber, pageSize)
                     .map(post -> mapper.toEducationAll(post, checkFileExistsByPost(post.getId())));
         }
 

--- a/src/main/java/leets/weeth/domain/board/domain/repository/PostRepository.java
+++ b/src/main/java/leets/weeth/domain/board/domain/repository/PostRepository.java
@@ -82,14 +82,15 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 		SELECT p
 		  FROM Post p
 		 WHERE p.category = :category
+		   AND (:cardinal IS NULL OR p.cardinalNumber = :cardinal)
 		   AND (
 				 :partName = 'ALL'
 			  OR FUNCTION('FIND_IN_SET', :partName, p.parts) > 0
 			  OR FUNCTION('FIND_IN_SET', 'ALL',    p.parts) > 0
-			 )
+			   )
 	  ORDER BY p.id DESC
 	""")
-	Slice<Post> findByCategoryWithPart(@Param("partName") String partName, @Param("category") Category category, Pageable pageable);
+	Slice<Post> findByCategoryAndOptionalCardinalWithPart(@Param("partName") String partName, @Param("category") Category category, @Param("cardinal") Integer cardinal, Pageable pageable);
 
 	@Query("""
 		SELECT p

--- a/src/main/java/leets/weeth/domain/board/domain/service/PostFindService.java
+++ b/src/main/java/leets/weeth/domain/board/domain/service/PostFindService.java
@@ -79,10 +79,10 @@ public class PostFindService {
         return postRepository.findByCategoryAndCardinalNumberWithPart(partName, Category.Education, cardinalNumber, pageable);
     }
 
-    public Slice<Post> findByCategory(Part part, Category category, int pageNumber, int pageSize) {
+    public Slice<Post> findByCategory(Part part, Category category, Integer cardinal, int pageNumber, int pageSize) {
         Pageable pageable = PageRequest.of(pageNumber, pageSize, Sort.by(Sort.Direction.DESC, "id"));
         String partName = (part != null ? part.name() : Part.ALL.name());
 
-        return postRepository.findByCategoryWithPart(partName, category, pageable);
+        return postRepository.findByCategoryAndOptionalCardinalWithPart(partName, category, cardinal, pageable);
     }
 }


### PR DESCRIPTION
## 🚨 문제

교육자료 조회시, 파트별 필터링만 작동하고 기수별 필터링이 작동하지않는 문제가 있었습니다

<br>

## 💭 원인

`ADMIN`, 일반 `USER` 계정 둘다로 테스트해봤는데
`ADMIN` 계정에서는 모든 교육자료를 다 보여주는 로직에서, 기수별로 필터링 적용이 안되고 있었어요

어드민으로 교육자료 조회시 분기처리 로직중에 해당하는 쿼리문 수정으로 오류 트래킹해서 반영완료했습니다

<img width="411" height="137" alt="image" src="https://github.com/user-attachments/assets/d3d3ea3d-dafd-4ecc-8379-0d3dbb12008c" />

`local`에서 `ADMIN` 계정 + `USER` 계정으로 아래 두가지 케이스 모두 테스트 완료했습니다

1. 기수로만 필터링 (`ALL` 파트)
2. 기수 + 파트로 필터링

<br>

## 체크 리스트

- [x] 리뷰어 설정
- [x] Assignee 설정
- [x] Label 설정
- [x] 제목 양식 맞췄나요? (ex. #0 Feat: 기능 추가)
- [x] 변경 사항에 대한 테스트