### PR TITLE
[WTH-27] weeth 게시글 제목 not blank 처리 및 댓글 제한 설정

### DIFF
--- a/src/main/java/leets/weeth/domain/board/application/dto/PostDTO.java
+++ b/src/main/java/leets/weeth/domain/board/application/dto/PostDTO.java
@@ -1,6 +1,7 @@
 package leets.weeth.domain.board.application.dto;
 
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -17,8 +18,8 @@ public class PostDTO {
 
     @Builder
     public record Save(
-            @NotNull String title,
-            @NotNull String content,
+            @NotBlank(message = "제목 입력은 필수입니다.") String title,
+            @NotBlank(message = "내용 입력은 필수입니다.") String content,
             @NotNull Category category,
             String studyName,
             int week,

--- a/src/main/java/leets/weeth/domain/comment/application/dto/CommentDTO.java
+++ b/src/main/java/leets/weeth/domain/comment/application/dto/CommentDTO.java
@@ -3,6 +3,7 @@ package leets.weeth.domain.comment.application.dto;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import leets.weeth.domain.file.application.dto.request.FileSaveRequest;
 import leets.weeth.domain.file.application.dto.response.FileResponse;
 import leets.weeth.domain.user.domain.entity.enums.Position;
@@ -17,13 +18,13 @@ public class CommentDTO {
     @Builder
     public record Save(
             Long parentCommentId,
-            @NotBlank String content,
+            @NotBlank @Size(max=300, message = "댓글은 최대 300자까지 가능합니다.") String content,
             @Valid List<@NotNull FileSaveRequest> files
     ){}
 
     @Builder
     public record Update(
-            @NotBlank String content,
+            @NotBlank @Size(max=300, message = "댓글은 최대 300자까지 가능합니다.") String content,
             @Valid List<@NotNull FileSaveRequest> files
     ){}
 

--- a/src/main/java/leets/weeth/domain/comment/domain/entity/Comment.java
+++ b/src/main/java/leets/weeth/domain/comment/domain/entity/Comment.java
@@ -27,6 +27,7 @@ public class Comment extends BaseEntity {
     @Column(name = "comment_id")
     private Long id;
 
+    @Column(length = 300)
     private String content;
 
     @Column(nullable = false)


### PR DESCRIPTION
## PR 내용

제목에 값을 입력하지 않아도 글이 생성됨
필드 확인 결과 내용(content)부분도 똑같은 현상발생 

댓글자수를 300자로 제한 (바이트는 600byte)

(*작업은 Local DB로 swagger로 테스트하였습니다)

## PR 세부사항

게시글 관련 문제는 @NotNull -> @NotBlank 처리

댓글자 수 관련은 DTO에 @Size로 유효성 검사, 엔티티에 @Column(length =300)으로 JPA매핑될때 300자 받게끔 설정 


<br>

## 관련 스크린샷

- 제목 값이 null일 때 (수정도 마찬가지)
<img width="1170" height="625" alt="스크린샷 2025-09-29 오후 3 37 42" src="https://github.com/user-attachments/assets/b26c8a2f-1fae-4372-a995-9c6caeadf955" />

- 제목+내용 값이 null 일 때 (수정도 마찬가지)

<img width="1166" height="621" alt="스크린샷 2025-09-29 오후 3 38 06" src="https://github.com/user-attachments/assets/653da252-0f8d-480c-ad1f-658368aab4f3" />

- 댓글 글자 수가 300자를 초과했을 경우 (수정도 포함)

<img width="1149" height="588" alt="스크린샷 2025-09-29 오후 6 32 38" src="https://github.com/user-attachments/assets/092df9f5-57ca-4dd4-b003-399df212832f" />


<br>

## 주의사항
@Column(length=300) 사용시 , JPA가 DB컬럼을 VARCHAR(300)으로 자동 생성해주는것으로 알고 있습니다.
강혁님이 바이트기준이라 600으로 해야한다 하셨는데, 서칭결과 글자 수기준으로 300으로 해도 충분하다고 생각되는데!

사실과 다른 부분있으면 피드백 부탁드립니다🙂 

<br>

## 체크 리스트

- [ ] 리뷰어 설정
- [ ] Assignee 설정
- [ ] Label 설정
- [ ] 제목 양식 맞췄나요? (ex. #0 Feat: 기능 추가)
- [ ] 변경 사항에 대한 테스트

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - 게시글 작성 시 제목·내용을 공백 불가로 검증하고 한국어 오류 메시지를 제공합니다.
  - 댓글 저장/수정 시 내용 길이를 최대 300자로 제한하며, 초과 시 한국어 오류 메시지를 표시합니다.
  - 댓글 내용 DB 컬럼 길이를 300자로 제한해 저장 오류와 데이터 불일치를 방지합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->