### PR TITLE
[WTH-35] Weeth 서버 성능 모니터링 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,10 @@ dependencies {
 	// Spring Authorization Server
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-authorization-server'
 
+    // Prometheus
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/leets/weeth/global/auth/jwt/filter/JwtAuthenticationProcessingFilter.java
+++ b/src/main/java/leets/weeth/global/auth/jwt/filter/JwtAuthenticationProcessingFilter.java
@@ -48,7 +48,7 @@ public class JwtAuthenticationProcessingFilter extends OncePerRequestFilter {
                 saveAuthentication(accessToken);
             }
         } catch (TokenNotFoundException e) {
-            // 로그 생략
+            log.debug("Token not found: {}", e.getMessage());
         } catch (RuntimeException e) {
             log.info("error token: {}", e.getMessage());
         }

--- a/src/main/java/leets/weeth/global/auth/jwt/filter/JwtAuthenticationProcessingFilter.java
+++ b/src/main/java/leets/weeth/global/auth/jwt/filter/JwtAuthenticationProcessingFilter.java
@@ -47,6 +47,8 @@ public class JwtAuthenticationProcessingFilter extends OncePerRequestFilter {
             if (jwtProvider.validate(accessToken)) {
                 saveAuthentication(accessToken);
             }
+        } catch (TokenNotFoundException e) {
+            // 로그 생략
         } catch (RuntimeException e) {
             log.info("error token: {}", e.getMessage());
         }

--- a/src/main/java/leets/weeth/global/config/SecurityConfig.java
+++ b/src/main/java/leets/weeth/global/config/SecurityConfig.java
@@ -80,7 +80,7 @@ public class SecurityConfig {
                                                 "/js/**", "/img/**", "/scss/**", "/vendor/**").permitAll()
                                         // 스웨거 경로
                                         .requestMatchers("/v3/api-docs", "/v3/api-docs/**", "/swagger-ui.html", "/swagger-ui/**", "/swagger/**").permitAll()
-                                        .requestMatchers("/actuator/prometheus").permitAll()
+                                        .requestMatchers("/actuator/health", "actuator/prometheus").permitAll()
                                         .requestMatchers("/api/v1/admin/**").hasRole("ADMIN")
                                         .anyRequest().authenticated()
                 )

--- a/src/main/java/leets/weeth/global/config/SecurityConfig.java
+++ b/src/main/java/leets/weeth/global/config/SecurityConfig.java
@@ -18,6 +18,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.ProviderManager;
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.authorization.AuthorizationDecision;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -80,7 +81,13 @@ public class SecurityConfig {
                                                 "/js/**", "/img/**", "/scss/**", "/vendor/**").permitAll()
                                         // 스웨거 경로
                                         .requestMatchers("/v3/api-docs", "/v3/api-docs/**", "/swagger-ui.html", "/swagger-ui/**", "/swagger/**").permitAll()
-                                        .requestMatchers("/actuator/health", "actuator/prometheus").permitAll()
+                                        .requestMatchers("/actuator/prometheus")
+                                            .access((authentication, context) -> {
+                                                String ip = context.getRequest().getRemoteAddr();
+                                                boolean allowed = ip.startsWith("172.") || ip.equals("127.0.0.1");
+                                                return new AuthorizationDecision(allowed);
+                                            })
+                                        .requestMatchers("/actuator/health").permitAll()
                                         .requestMatchers("/api/v1/admin/**").hasRole("ADMIN")
                                         .anyRequest().authenticated()
                 )

--- a/src/main/java/leets/weeth/global/config/SecurityConfig.java
+++ b/src/main/java/leets/weeth/global/config/SecurityConfig.java
@@ -80,6 +80,7 @@ public class SecurityConfig {
                                                 "/js/**", "/img/**", "/scss/**", "/vendor/**").permitAll()
                                         // 스웨거 경로
                                         .requestMatchers("/v3/api-docs", "/v3/api-docs/**", "/swagger-ui.html", "/swagger-ui/**", "/swagger/**").permitAll()
+                                        .requestMatchers("/actuator/prometheus").permitAll()
                                         .requestMatchers("/api/v1/admin/**").hasRole("ADMIN")
                                         .anyRequest().authenticated()
                 )

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -44,7 +44,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: "*"
+        include: "health,prometheus"
   prometheus:
     metrics:
       export:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -44,7 +44,9 @@ management:
   endpoints:
     web:
       exposure:
-        include: "health,prometheus"
+        include:
+          - health
+          - prometheus
   prometheus:
     metrics:
       export:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -39,3 +39,13 @@ auth:
       scopes: ${LEENK_SCOPES}
       accessTokenTtl: ${LEENK_ACCESS_TOKEN_TTL}
       refreshTokenTtl: ${LEENK_REFRESH_TOKEN_TTL}
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: "*"
+  prometheus:
+    metrics:
+      export:
+        enabled: true


### PR DESCRIPTION
## PR 내용
- 프로메테우스 & 그라파나 모니터링 추가

<br>

## PR 세부사항
- `/actuator/prometheus`에서 정보를 가져올 때마다 `error token: 헤더에서 토큰을 찾을 수 없습니다.` 경고 메세지가 뜨는 문제가 발생
  - 회의 결과 토큰이 아예 없는 경우엔 로그를 남기지 않도록 수정
- docker-compose 수정
  - prometheus, grafana, node-exporter 서비스 추가
  - 현재 dev 서버에는 적용하지 않았으며, 머지 시점에 적용 예정

**추가**
-  IP 화이트리스트를 통해 ec2 및 도커 컨테이너 내부 인터넷만 `/actuator/prometheus` 접근 가능하도록 수정
- `/actuator/health` 외부 접근 허용
- docker-compose.yml 에서 프로메테우스, node-exporter 포트는 내부 컨테이너만 접근 가능하도록 수정

<br>

## 관련 스크린샷
- 서버 전체 CPU 예시
<img width="2780" height="1566" alt="image" src="https://github.com/user-attachments/assets/89b52858-ef83-479f-ac89-b0b736c77301" />
- 메트릭
<img width="3434" height="1704" alt="image" src="https://github.com/user-attachments/assets/58c465cb-8f0b-40dd-be92-183649f04ac2" />


<br>

## 주의사항
- ~~Node Exporter, Prometheus, Grafana 포트는 외부 인터넷에서 직접 접근하지 못하도록 보안 그룹에서 제한해야합니다~~
- 컨테이너 내부에서만 접근 가능하도록 수정
<br>

## 체크 리스트

- [x] 리뷰어 설정
- [x] Assignee 설정
- [ ] Label 설정
- [x] 제목 양식 맞췄나요? (ex. #0 Feat: 기능 추가)
- [x] 변경 사항에 대한 테스트

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 애플리케이션 모니터링용 Prometheus 통합 추가로 메트릭 수집 및 조회 지원

* **Bug Fixes**
  * 인증 토큰 미발견 상황에 대한 예외 처리 및 디버그 로그 추가로 인증 흐름 안정성 향상

* **Chores**
  * 관리 엔드포인트 노출 범위 조정: 헬스는 공개 허용, Prometheus는 내부 IP에서만 접근 허용 및 메트릭 내보내기 활성화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->