### PR TITLE
[WTH-42] 유저 테스트 코드 작성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,11 @@ dependencies {
 
 	// Test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation "org.junit.jupiter:junit-jupiter:5.8.1"
+	testImplementation "org.testcontainers:testcontainers:2.0.1"
+	testImplementation "org.testcontainers:testcontainers-junit-jupiter:2.0.1"
+	testImplementation "org.testcontainers:testcontainers-mysql:2.0.1"
+	testImplementation 'org.springframework.boot:spring-boot-testcontainers'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
 	// Swagger

--- a/src/test/java/leets/weeth/config/TestContainersConfig.java
+++ b/src/test/java/leets/weeth/config/TestContainersConfig.java
@@ -1,0 +1,19 @@
+package leets.weeth.config;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Bean;
+import org.testcontainers.mysql.MySQLContainer;
+import org.testcontainers.utility.DockerImageName;
+
+@TestConfiguration
+public class TestContainersConfig {
+	private static final String MYSQL_IMAGE = "mysql:8.0.41";
+
+	@Bean
+	@ServiceConnection
+	public MySQLContainer mysqlContainer() {
+		return new MySQLContainer(DockerImageName.parse(MYSQL_IMAGE))
+			.withReuse(true);
+	}
+}

--- a/src/test/java/leets/weeth/config/TestContainersTest.java
+++ b/src/test/java/leets/weeth/config/TestContainersTest.java
@@ -1,0 +1,25 @@
+package leets.weeth.config;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.testcontainers.mysql.MySQLContainer;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+@DataJpaTest
+@Import(TestContainersConfig.class)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class TestContainersTest {
+	@Autowired
+	private MySQLContainer mysqlContainer;
+
+	@Test
+	void 설정파일로_주입된_컨테이너_정상_동작_테스트() {
+		assertThat(mysqlContainer).isNotNull();
+		assertThat(mysqlContainer.isRunning()).isTrue();
+		System.out.println("Container JDBC URL: " + mysqlContainer.getJdbcUrl());
+	}
+}

--- a/src/test/java/leets/weeth/domain/user/application/usecase/CardinalUseCaseTest.java
+++ b/src/test/java/leets/weeth/domain/user/application/usecase/CardinalUseCaseTest.java
@@ -13,6 +13,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import leets.weeth.domain.user.application.dto.request.CardinalSaveRequest;
+import leets.weeth.domain.user.application.dto.request.CardinalUpdateRequest;
 import leets.weeth.domain.user.application.mapper.CardinalMapper;
 import leets.weeth.domain.user.domain.entity.Cardinal;
 import leets.weeth.domain.user.domain.entity.enums.CardinalStatus;
@@ -112,18 +113,22 @@ public class CardinalUseCaseTest {
 
 
 	@Test
-	void update_진행상태가_변하지_않는다면_단순_업데이트만() {
+	void update_연도와_학기를_변경한다() {
 		//given
+		var cardinal = Cardinal.builder()
+			.year(2024)
+			.semester(2)
+			.build();
+		var dto = new CardinalUpdateRequest(1L, 2025,1,false);
+
 		//when
+		cardinal.update(dto);
+
 		//then
+		assertThat(cardinal.getYear()).isEqualTo(2025);
+		assertThat(cardinal.getSemester()).isEqualTo(1);
 	}
 
-	@Test
-	void update_진행중으로_변경되면_기존은_done처리_현재는_inProgress() {
-		//given
-		//when
-		//then
-	}
 
 	@Test
 	void finaALl_조회된_모든_기수를_DTO로_매핑처리() {

--- a/src/test/java/leets/weeth/domain/user/application/usecase/CardinalUseCaseTest.java
+++ b/src/test/java/leets/weeth/domain/user/application/usecase/CardinalUseCaseTest.java
@@ -1,6 +1,10 @@
 package leets.weeth.domain.user.application.usecase;
 
+import static org.assertj.core.api.AssertionsForClassTypes.*;
 import static org.mockito.BDDMockito.*;
+
+import java.util.List;
+import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -66,10 +70,46 @@ public class CardinalUseCaseTest {
 
 	@Test
 	void save_새_기수가_진행중이라면_기존_기수는_done_현재기수는_inProgress() {
-		//given
-		//when
-		//then
+		// given
+		var request = new CardinalSaveRequest(7, 2025,1,true);
+
+		var oldCardinal = Cardinal.builder()
+			.cardinalNumber(6)
+			.year(2024)
+			.semester(2)
+			.status(CardinalStatus.IN_PROGRESS)
+			.build();
+
+		var newCardinalBeforeSave = Cardinal.builder()
+			.cardinalNumber(7)
+			.year(2025)
+			.semester(1)
+			.status(CardinalStatus.DONE)
+			.build();
+
+		var newCardinalAfterSave = Cardinal.builder()
+			.cardinalNumber(7)
+			.year(2025)
+			.semester(1)
+			.status(CardinalStatus.IN_PROGRESS)
+			.build();
+
+
+		given(cardinalGetService.findInProgress()).willReturn(List.of(oldCardinal));
+		given(cardinalMapper.from(request)).willReturn(newCardinalBeforeSave);
+		given(cardinalSaveService.save(newCardinalBeforeSave)).willReturn(newCardinalAfterSave);
+
+		// when
+		useCase.save(request);
+
+		// then
+		then(cardinalGetService).should().findInProgress();
+		then(cardinalSaveService).should().save(newCardinalBeforeSave);
+
+		assertThat(oldCardinal.getStatus()).isEqualTo(CardinalStatus.DONE);
+		assertThat(newCardinalAfterSave.getStatus()).isEqualTo(CardinalStatus.IN_PROGRESS);
 	}
+
 
 	@Test
 	void update_진행상태가_변하지_않는다면_단순_업데이트만() {

--- a/src/test/java/leets/weeth/domain/user/application/usecase/CardinalUseCaseTest.java
+++ b/src/test/java/leets/weeth/domain/user/application/usecase/CardinalUseCaseTest.java
@@ -22,6 +22,7 @@ import leets.weeth.domain.user.domain.entity.Cardinal;
 import leets.weeth.domain.user.domain.entity.enums.CardinalStatus;
 import leets.weeth.domain.user.domain.service.CardinalGetService;
 import leets.weeth.domain.user.domain.service.CardinalSaveService;
+import leets.weeth.domain.user.test.fixture.CardinalTestFixture;
 
 @ExtendWith(MockitoExtension.class)
 public class CardinalUseCaseTest {
@@ -46,18 +47,8 @@ public class CardinalUseCaseTest {
 		//given
 		var request = new CardinalSaveRequest(7, 2025,1,false);
 
-		var toSave = Cardinal.builder() //DB저장되기 전의 객체
-			.cardinalNumber(7)
-			.year(2025)
-			.semester(1)
-			.build();
-
-		var saved = Cardinal.builder()// 저장되고 난 후 반환된 객체
-			.cardinalNumber(7)
-			.year(2025)
-			.semester(1)
-			.status(CardinalStatus.DONE)
-			.build();
+		var toSave = CardinalTestFixture.createCardinal(7, 2025, 1);
+		var saved =  CardinalTestFixture.createCardinal(7,2025 ,1);
 
 		willDoNothing().given(cardinalGetService).validateCardinal(7);
 		given(cardinalMapper.from(request)).willReturn(toSave);
@@ -77,27 +68,9 @@ public class CardinalUseCaseTest {
 		// given
 		var request = new CardinalSaveRequest(7, 2025,1,true);
 
-		var oldCardinal = Cardinal.builder()
-			.cardinalNumber(6)
-			.year(2024)
-			.semester(2)
-			.status(CardinalStatus.IN_PROGRESS)
-			.build();
-
-		var newCardinalBeforeSave = Cardinal.builder()
-			.cardinalNumber(7)
-			.year(2025)
-			.semester(1)
-			.status(CardinalStatus.DONE)
-			.build();
-
-		var newCardinalAfterSave = Cardinal.builder()
-			.cardinalNumber(7)
-			.year(2025)
-			.semester(1)
-			.status(CardinalStatus.IN_PROGRESS)
-			.build();
-
+		var oldCardinal = CardinalTestFixture.createCardinalInProgress(6, 2024, 2);
+		var newCardinalBeforeSave = CardinalTestFixture.createCardinal(7, 2025, 1);
+		var newCardinalAfterSave = CardinalTestFixture.createCardinal(7, 2025, 1);
 
 		given(cardinalGetService.findInProgress()).willReturn(List.of(oldCardinal));
 		given(cardinalMapper.from(request)).willReturn(newCardinalBeforeSave);
@@ -118,10 +91,7 @@ public class CardinalUseCaseTest {
 	@Test
 	void update_연도와_학기를_변경한다() {
 		//given
-		var cardinal = Cardinal.builder()
-			.year(2024)
-			.semester(2)
-			.build();
+		var cardinal = CardinalTestFixture.createCardinal(6, 2024, 2);
 		var dto = new CardinalUpdateRequest(1L, 2025,1,false);
 
 		//when
@@ -137,24 +107,9 @@ public class CardinalUseCaseTest {
 	void findAll_조회된_모든_기수를_DTO로_매핑처리() {
 
 		//given
-		var cardinal1 = Cardinal.builder()
-			.id(1L)
-			.cardinalNumber(6)
-			.year(2024)
-			.semester(2)
-			.status(CardinalStatus.DONE)
-			.build();
-
-		var cardinal2 = Cardinal.builder()
-			.id(2L)
-			.cardinalNumber(7)
-			.year(2025)
-			.semester(1)
-			.status(CardinalStatus.IN_PROGRESS)
-			.build();
-
+		var cardinal1 = CardinalTestFixture.createCardinal(1L,6,2024,2);
+		var cardinal2 = CardinalTestFixture.createCardinalInProgress(2L,7,2025,1);
 		var cardinals = List.of(cardinal1, cardinal2);
-
 		var now = LocalDateTime.now();
 
 		var response1 = new CardinalResponse(

--- a/src/test/java/leets/weeth/domain/user/application/usecase/CardinalUseCaseTest.java
+++ b/src/test/java/leets/weeth/domain/user/application/usecase/CardinalUseCaseTest.java
@@ -1,0 +1,97 @@
+package leets.weeth.domain.user.application.usecase;
+
+import static org.mockito.BDDMockito.*;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import leets.weeth.domain.user.application.dto.request.CardinalSaveRequest;
+import leets.weeth.domain.user.application.mapper.CardinalMapper;
+import leets.weeth.domain.user.domain.entity.Cardinal;
+import leets.weeth.domain.user.domain.entity.enums.CardinalStatus;
+import leets.weeth.domain.user.domain.service.CardinalGetService;
+import leets.weeth.domain.user.domain.service.CardinalSaveService;
+
+@ExtendWith(MockitoExtension.class)
+public class CardinalUseCaseTest {
+	// 실제 CardinalUseCase에서 사용하는 의존성을 Mock 객체로 대신 주입
+	@Mock
+	private CardinalGetService cardinalGetService;
+
+	@Mock
+	private CardinalSaveService cardinalSaveService;
+
+	@Mock
+	private CardinalMapper cardinalMapper;
+
+	@InjectMocks
+	private CardinalUseCase useCase;
+
+	// Given-When-Then 패턴을 쉽게 이해하기 위해 메서드명_상황_예상결과로  테스트 메서드 네이밍
+
+
+	@Test // 진행중이 아닌 기수를 등록하는 경우
+	void save_진행중이_아닌_기수라면_검증후_저장만() {
+		//given
+		var request = new CardinalSaveRequest(7, 2025,1,false);
+
+		var toSave = Cardinal.builder() //DB저장되기 전의 객체
+			.cardinalNumber(7)
+			.year(2025)
+			.semester(1)
+			.build();
+
+		var saved = Cardinal.builder()// 저장되고 난 후 반환된 객체
+			.cardinalNumber(7)
+			.year(2025)
+			.semester(1)
+			.status(CardinalStatus.DONE)
+			.build();
+
+		willDoNothing().given(cardinalGetService).validateCardinal(7);
+		given(cardinalMapper.from(request)).willReturn(toSave);
+		given(cardinalSaveService.save(toSave)).willReturn(saved);
+
+		//when
+		useCase.save(request);
+
+		//then
+		then(cardinalGetService).should().validateCardinal(7);
+		then(cardinalSaveService).should().save(toSave);
+		then(cardinalGetService).should(never()).findInProgress();
+	}
+
+	@Test
+	void save_새_기수가_진행중이라면_기존_기수는_done_현재기수는_inProgress() {
+		//given
+		//when
+		//then
+	}
+
+	@Test
+	void update_진행상태가_변하지_않는다면_단순_업데이트만() {
+		//given
+		//when
+		//then
+	}
+
+	@Test
+	void update_진행중으로_변경되면_기존은_done처리_현재는_inProgress() {
+		//given
+		//when
+		//then
+	}
+
+	@Test
+	void finaALl_조회된_모든_기수를_DTO로_매핑처리() {
+
+	}
+
+
+
+
+
+}

--- a/src/test/java/leets/weeth/domain/user/application/usecase/UserManageUseCaseTest.java
+++ b/src/test/java/leets/weeth/domain/user/application/usecase/UserManageUseCaseTest.java
@@ -102,7 +102,7 @@ public class UserManageUseCaseTest {
 
 		given(userCardinalGetService.getUserCardinals(user1)).willReturn(List.of(uc1));
 		given(userCardinalGetService.getUserCardinals(user2)).willReturn(List.of(uc2));
-		given(userCardinalGetService.findAll()).willReturn(List.of(uc1, uc2));
+		given(userCardinalGetService.findAll()).willReturn(List.of(uc2, uc1));
 		given(userMapper.toAdminResponse(user1, List.of(uc1))).willReturn(adminResponse1);
 		given(userMapper.toAdminResponse(user2, List.of(uc2))).willReturn(adminResponse2);
 

--- a/src/test/java/leets/weeth/domain/user/application/usecase/UserManageUseCaseTest.java
+++ b/src/test/java/leets/weeth/domain/user/application/usecase/UserManageUseCaseTest.java
@@ -36,6 +36,8 @@ import leets.weeth.domain.user.domain.service.UserCardinalSaveService;
 import leets.weeth.domain.user.domain.service.UserDeleteService;
 import leets.weeth.domain.user.domain.service.UserGetService;
 import leets.weeth.domain.user.domain.service.UserUpdateService;
+import leets.weeth.domain.user.test.fixture.CardinalTestFixture;
+import leets.weeth.domain.user.test.fixture.UserTestFixture;
 import leets.weeth.global.auth.jwt.service.JwtRedisService;
 
 @ExtendWith(MockitoExtension.class)
@@ -75,32 +77,10 @@ public class UserManageUseCaseTest {
 		//given
 		UsersOrderBy orderBy = UsersOrderBy.NAME_ASCENDING;
 
-		var user1  = User.builder()
-			.id(1L)
-			.name("aaa")
-			.status(Status.ACTIVE)
-			.build();
-
-		var user2  = User.builder()
-			.id(2L)
-			.name("bbb")
-			.status(Status.WAITING)
-			.build();
-
-		var cd1 = Cardinal.builder()
-			.id(1L)
-			.cardinalNumber(6)
-			.year(2020)
-			.semester(2)
-			.build();
-
-		var cd2 = Cardinal.builder()
-			.id(2L)
-			.cardinalNumber(7)
-			.year(2021)
-			.semester(1)
-			.build();
-
+		var user1 = UserTestFixture.createActiveUser1();
+		var user2 = UserTestFixture.createWaitingUser2();
+		var cd1 = CardinalTestFixture.createCardinal(1L,6,2020,2);
+		var cd2 = CardinalTestFixture.createCardinal(2L,7,2021,1);
 		var uc1 = new UserCardinal(user1, cd1);
 		var uc2 = new UserCardinal(user2, cd2);
 
@@ -119,8 +99,6 @@ public class UserManageUseCaseTest {
 			LocalDateTime.now().minusDays(2),
 			LocalDateTime.now()
 		);
-
-
 
 		given(userCardinalGetService.getUserCardinals(user1)).willReturn(List.of(uc1));
 		given(userCardinalGetService.getUserCardinals(user2)).willReturn(List.of(uc2));
@@ -144,16 +122,9 @@ public class UserManageUseCaseTest {
 	@Test
 	void accept_비활성유저_승인시_출석초기화_정상호출되는지() {
 		//given
-		var user1 = User.builder()
-			.id(1L)
-			.name("aaa")
-			.status(Status.WAITING)
-			.build();
+		var user1 = UserTestFixture.createWaitingUser1(1L);
 		var userIds = new UserRequestDto.UserId(List.of(1L));
-		var cardinal = Cardinal.builder()
-			.id(1L)
-			.cardinalNumber(8)
-			.build();
+		var cardinal = CardinalTestFixture.createCardinal(1L,8,2020,2);
 		var meetings = List.of(mock(Meeting.class));
 
 		given(userGetService.findAll(userIds.userId())).willReturn(List.of(user1));
@@ -172,7 +143,7 @@ public class UserManageUseCaseTest {
 	@Test
 	void update_유저권한변경시_DB와_Redis_모두갱신되는지() {
 		// given
-		var user1 = User.builder().id(1L).build();
+		var user1 = UserTestFixture.createActiveUser1(1L);
 		var request = new UserRequestDto.UserRoleUpdate(1L, Role.ADMIN);
 
 		lenient().when(userGetService.find((Long)1L)).thenReturn(user1);
@@ -188,10 +159,7 @@ public class UserManageUseCaseTest {
 	@Test
 	void leave_회원탈퇴시_토큰무효화_및_유저상태변경되는지() {
 		//given
-		var user1 = User.builder().
-			id(1L)
-			.status(Status.ACTIVE)
-			.build();
+		var user1 = UserTestFixture.createActiveUser1(1L);
 		given(userGetService.find((Long)1L)).willReturn(user1);
 
 		//when
@@ -206,11 +174,7 @@ public class UserManageUseCaseTest {
 	@Test
 	void ban_회원ban시_토큰무효화_및_유저상태변경되는지() {
 		//given
-		var user1 = User.builder().
-			id(1L)
-			.status(Status.ACTIVE)
-			.build();
-
+		var user1 = UserTestFixture.createActiveUser1(1L);
 		var ids = new UserRequestDto.UserId(List.of(1L));
 		given(userGetService.findAll(ids.userId())).willReturn(List.of(user1));
 
@@ -226,17 +190,8 @@ public class UserManageUseCaseTest {
 	@Test
 	void applyOB_현재기수_OB신청시_출석초기화_및_기수업데이트() {
 		//given
-		var user = User.builder()
-			.id(1L)
-			.status(Status.ACTIVE)
-			.attendances(new ArrayList<>())
-			.build();
-
-		var nextCardinal = Cardinal.builder()
-			.id(1L)
-			.cardinalNumber(4)
-			.build();
-
+		var user = User.builder().id(1L).name("aaa").status(Status.ACTIVE).attendances(new ArrayList<>()).build();
+		var nextCardinal = CardinalTestFixture.createCardinal(1L,4,2020,2);
 		var request = new UserRequestDto.UserApplyOB(1L,4);
 		var meeting = List.of(mock(Meeting.class));
 
@@ -257,18 +212,8 @@ public class UserManageUseCaseTest {
 	@Test
 	void reset_비밀번호초기화시_모든유저에_reset호출되는지() {
 		// given
-		var user1 = User.builder()
-			.id(1L)
-			.name("aaa")
-			.status(Status.ACTIVE)
-			.build();
-
-		var user2 = User.builder()
-			.id(2L)
-			.name("bbb")
-			.status(Status.ACTIVE)
-			.build();
-
+		var user1 = UserTestFixture.createActiveUser1(1L);
+		var user2 = UserTestFixture.createActiveUser2(2L);
 		var ids = new UserRequestDto.UserId(List.of(1L, 2L));
 
 		given(userGetService.findAll(ids.userId())).willReturn(List.of(user1, user2));

--- a/src/test/java/leets/weeth/domain/user/application/usecase/UserManageUseCaseTest.java
+++ b/src/test/java/leets/weeth/domain/user/application/usecase/UserManageUseCaseTest.java
@@ -1,0 +1,139 @@
+package leets.weeth.domain.user.application.usecase;
+
+
+import static org.assertj.core.api.Assertions.*;
+
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import static org.mockito.BDDMockito.given;
+
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import leets.weeth.domain.attendance.domain.service.AttendanceSaveService;
+import leets.weeth.domain.schedule.domain.service.MeetingGetService;
+import leets.weeth.domain.user.application.dto.response.UserResponseDto;
+import leets.weeth.domain.user.application.exception.InvalidUserOrderException;
+import leets.weeth.domain.user.application.mapper.UserMapper;
+import leets.weeth.domain.user.domain.entity.Cardinal;
+import leets.weeth.domain.user.domain.entity.User;
+import leets.weeth.domain.user.domain.entity.UserCardinal;
+import leets.weeth.domain.user.domain.entity.enums.Status;
+import leets.weeth.domain.user.domain.entity.enums.UsersOrderBy;
+import leets.weeth.domain.user.domain.service.CardinalGetService;
+import leets.weeth.domain.user.domain.service.UserCardinalGetService;
+import leets.weeth.domain.user.domain.service.UserCardinalSaveService;
+import leets.weeth.domain.user.domain.service.UserDeleteService;
+import leets.weeth.domain.user.domain.service.UserGetService;
+import leets.weeth.domain.user.domain.service.UserUpdateService;
+import leets.weeth.global.auth.jwt.service.JwtRedisService;
+
+@ExtendWith(MockitoExtension.class)
+public class UserManageUseCaseTest {
+
+	@Mock private UserGetService userGetService;
+	@Mock private UserUpdateService userUpdateService;
+	@Mock private UserDeleteService userDeleteService;
+
+	@Mock private AttendanceSaveService attendanceSaveService;
+	@Mock private MeetingGetService meetingGetService;
+	@Mock private JwtRedisService jwtRedisService;
+	@Mock private CardinalGetService cardinalGetService;
+	@Mock private UserCardinalSaveService userCardinalSaveService;
+	@Mock private UserCardinalGetService userCardinalGetService;
+
+	@Mock private UserMapper userMapper;
+	@Mock private PasswordEncoder passwordEncoder;
+
+	@InjectMocks
+	private UserManageUseCaseImpl useCase;
+
+
+	@Test
+	void findAllByAdmin_orderBy가_null이면_예외가정상발생하는지(){
+		//given
+		UsersOrderBy orderBy = null;
+
+		//when & then
+		assertThatThrownBy(() -> useCase.findAllByAdmin(orderBy))
+			.isInstanceOf(InvalidUserOrderException.class);
+
+	}
+
+	@Test
+	void findAllByAdmin이_orderBy에_맞게_정렬되어_조회되는지() {
+		//given
+		UsersOrderBy orderBy = UsersOrderBy.NAME_ASCENDING;
+
+		var user1  = User.builder()
+			.id(1L)
+			.name("aaa")
+			.status(Status.ACTIVE)
+			.build();
+
+		var user2  = User.builder()
+			.id(2L)
+			.name("bbb")
+			.status(Status.WAITING)
+			.build();
+
+		var cd1 = Cardinal.builder()
+			.id(1L)
+			.cardinalNumber(6)
+			.year(2020)
+			.semester(2)
+			.build();
+
+		var cd2 = Cardinal.builder()
+			.id(2L)
+			.cardinalNumber(7)
+			.year(2021)
+			.semester(1)
+			.build();
+
+		var uc1 = new UserCardinal(user1, cd1);
+		var uc2 = new UserCardinal(user2, cd2);
+
+		var adminResponse1 = new UserResponseDto.AdminResponse(
+			1, "aaa", "a@a.com", "202034420", "01011112222", "산업공학과",
+			List.of(6), null, Status.ACTIVE, null,
+			0, 0, 0, 0, 0,
+			LocalDateTime.now().minusDays(3),
+			LocalDateTime.now()
+		);
+
+		var adminResponse2 = new UserResponseDto.AdminResponse(
+			2, "bbb", "b@b.com", "202045678", "01033334444", "컴퓨터공학과",
+			List.of(7), null, Status.WAITING, null,
+			0, 0, 0, 0, 0,
+			LocalDateTime.now().minusDays(2),
+			LocalDateTime.now()
+		);
+
+
+
+		given(userCardinalGetService.getUserCardinals(user1)).willReturn(List.of(uc1));
+		given(userCardinalGetService.getUserCardinals(user2)).willReturn(List.of(uc2));
+		given(userCardinalGetService.findAll()).willReturn(List.of(uc1, uc2));
+		given(userMapper.toAdminResponse(user1, List.of(uc1))).willReturn(adminResponse1);
+		given(userMapper.toAdminResponse(user2, List.of(uc2))).willReturn(adminResponse2);
+
+
+		//when
+		var result = useCase.findAllByAdmin(UsersOrderBy.NAME_ASCENDING);
+
+
+		//then
+		assertThat(result).hasSize(2);
+		assertThat(result.get(0).name()).isEqualTo("aaa");
+		assertThat(result.get(1).name()).isEqualTo("bbb");
+
+	}
+
+}

--- a/src/test/java/leets/weeth/domain/user/application/usecase/UserManageUseCaseTest.java
+++ b/src/test/java/leets/weeth/domain/user/application/usecase/UserManageUseCaseTest.java
@@ -253,4 +253,33 @@ public class UserManageUseCaseTest {
 		then(attendanceSaveService).should().init(user,meeting);
 		then(userCardinalSaveService).should().save(any(UserCardinal.class));
 	}
+
+	@Test
+	void reset_비밀번호초기화시_모든유저에_reset호출되는지() {
+		// given
+		var user1 = User.builder()
+			.id(1L)
+			.name("aaa")
+			.status(Status.ACTIVE)
+			.build();
+
+		var user2 = User.builder()
+			.id(2L)
+			.name("bbb")
+			.status(Status.ACTIVE)
+			.build();
+
+		var ids = new UserRequestDto.UserId(List.of(1L, 2L));
+
+		given(userGetService.findAll(ids.userId())).willReturn(List.of(user1, user2));
+
+		// when
+		useCase.reset(ids);
+
+		// then
+		then(userGetService).should().findAll(ids.userId());
+		then(userUpdateService).should().reset(user1, passwordEncoder);
+		then(userUpdateService).should().reset(user2, passwordEncoder);
+	}
+
 }

--- a/src/test/java/leets/weeth/domain/user/application/usecase/UserManageUseCaseTest.java
+++ b/src/test/java/leets/weeth/domain/user/application/usecase/UserManageUseCaseTest.java
@@ -6,6 +6,7 @@ import static org.mockito.BDDMockito.*;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -25,6 +26,7 @@ import leets.weeth.domain.user.application.mapper.UserMapper;
 import leets.weeth.domain.user.domain.entity.Cardinal;
 import leets.weeth.domain.user.domain.entity.User;
 import leets.weeth.domain.user.domain.entity.UserCardinal;
+import leets.weeth.domain.user.domain.entity.enums.Role;
 import leets.weeth.domain.user.domain.entity.enums.Status;
 import leets.weeth.domain.user.domain.entity.enums.UsersOrderBy;
 import leets.weeth.domain.user.domain.service.CardinalGetService;
@@ -164,6 +166,22 @@ public class UserManageUseCaseTest {
 		then(userUpdateService).should().accept(user1);
 		then(attendanceSaveService).should().init(user1,meetings);
 
+	}
+
+	@Test
+	void update_유저권한변경시_DB와_Redis_모두갱신되는지() {
+		// given
+		var user1 = User.builder().id(1L).build();
+		var request = new UserRequestDto.UserRoleUpdate(1L, Role.ADMIN);
+
+		lenient().when(userGetService.find((Long)1L)).thenReturn(user1);
+
+		// when
+		useCase.update(List.of(request));
+
+		// then
+		then(userUpdateService).should().update(user1, "ADMIN");
+		then(jwtRedisService).should().updateRole(1L, "ADMIN");
 	}
 
 }

--- a/src/test/java/leets/weeth/domain/user/application/usecase/UserManageUseCaseTest.java
+++ b/src/test/java/leets/weeth/domain/user/application/usecase/UserManageUseCaseTest.java
@@ -202,5 +202,23 @@ public class UserManageUseCaseTest {
 
 	}
 
+	@Test
+	void ban_회원ban시_토큰무효화_및_유저상태변경되는지() {
+		//given
+		var user1 = User.builder().
+			id(1L)
+			.status(Status.ACTIVE)
+			.build();
 
+		var ids = new UserRequestDto.UserId(List.of(1L));
+		given(userGetService.findAll(ids.userId())).willReturn(List.of(user1));
+
+		//when
+		useCase.ban(ids);
+
+		//then
+		then(jwtRedisService).should().delete(1L);
+		then(userDeleteService).should().ban(user1);
+
+	}
 }

--- a/src/test/java/leets/weeth/domain/user/application/usecase/UserManageUseCaseTest.java
+++ b/src/test/java/leets/weeth/domain/user/application/usecase/UserManageUseCaseTest.java
@@ -184,4 +184,23 @@ public class UserManageUseCaseTest {
 		then(jwtRedisService).should().updateRole(1L, "ADMIN");
 	}
 
+	@Test
+	void leave_회원탈퇴시_토큰무효화_및_유저상태변경되는지() {
+		//given
+		var user1 = User.builder().
+			id(1L)
+			.status(Status.ACTIVE)
+			.build();
+		given(userGetService.find((Long)1L)).willReturn(user1);
+
+		//when
+		useCase.leave(1L);
+
+		//then
+		then(jwtRedisService).should().delete(1L);
+		then(userDeleteService).should().leave(user1);
+
+	}
+
+
 }

--- a/src/test/java/leets/weeth/domain/user/domain/repository/CardinalRepositoryTest.java
+++ b/src/test/java/leets/weeth/domain/user/domain/repository/CardinalRepositoryTest.java
@@ -1,0 +1,42 @@
+package leets.weeth.domain.user.domain.repository;
+
+import static org.assertj.core.api.AssertionsForClassTypes.*;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import leets.weeth.config.TestContainersConfig;
+import leets.weeth.domain.user.domain.entity.Cardinal;
+
+@DataJpaTest
+@Import(TestContainersConfig.class)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+public class CardinalRepositoryTest {
+
+	@Autowired
+	CardinalRepository cardinalRepository;
+
+	@Test
+	void 기수번호로_조회되는지() {
+		//given
+		Cardinal cardinal = Cardinal.builder()
+			.id(1L)
+			.cardinalNumber(7)
+			.year(2025)
+			.semester(1)
+			.build();
+		cardinalRepository.save(cardinal);
+
+		//when
+		var result = cardinalRepository.findByCardinalNumber(7);
+
+		//then
+		assertThat(result).isPresent();
+		assertThat(result.get().getYear()).isEqualTo(2025);
+	}
+
+
+}

--- a/src/test/java/leets/weeth/domain/user/domain/repository/CardinalRepositoryTest.java
+++ b/src/test/java/leets/weeth/domain/user/domain/repository/CardinalRepositoryTest.java
@@ -10,6 +10,7 @@ import org.springframework.context.annotation.Import;
 
 import leets.weeth.config.TestContainersConfig;
 import leets.weeth.domain.user.domain.entity.Cardinal;
+import leets.weeth.domain.user.test.fixture.CardinalTestFixture;
 
 @DataJpaTest
 @Import(TestContainersConfig.class)
@@ -22,12 +23,7 @@ public class CardinalRepositoryTest {
 	@Test
 	void 기수번호로_조회되는지() {
 		//given
-		Cardinal cardinal = Cardinal.builder()
-			.id(1L)
-			.cardinalNumber(7)
-			.year(2025)
-			.semester(1)
-			.build();
+		var cardinal = CardinalTestFixture.createCardinal(7,2025,1);
 		cardinalRepository.save(cardinal);
 
 		//when

--- a/src/test/java/leets/weeth/domain/user/domain/repository/UserCardinalRepositoryTest.java
+++ b/src/test/java/leets/weeth/domain/user/domain/repository/UserCardinalRepositoryTest.java
@@ -12,17 +12,14 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 
 import leets.weeth.config.TestContainersConfig;
-import leets.weeth.domain.user.domain.entity.Cardinal;
-import leets.weeth.domain.user.domain.entity.User;
 import leets.weeth.domain.user.domain.entity.UserCardinal;
-import leets.weeth.domain.user.domain.entity.enums.Status;
 import leets.weeth.domain.user.test.fixture.CardinalTestFixture;
 import leets.weeth.domain.user.test.fixture.UserTestFixture;
 
 @DataJpaTest
 @Import(TestContainersConfig.class)
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-public class UsesrCardinalRepositoryTest {
+public class UserCardinalRepositoryTest {
 
 	@Autowired
 	UserRepository userRepository;

--- a/src/test/java/leets/weeth/domain/user/domain/repository/UserRepositoryTest.java
+++ b/src/test/java/leets/weeth/domain/user/domain/repository/UserRepositoryTest.java
@@ -50,11 +50,12 @@ public class UserRepositoryTest {
 
 		user1.accept();
 		user2.accept();
+		userCardinalRepository.flush();
 
 		userCardinalRepository.save(UserCardinalTestFixture.linkUserCardinal(user1, cardinal7));
 		userCardinalRepository.save(UserCardinalTestFixture.linkUserCardinal(user2, cardinal8));
 		userCardinalRepository.save(UserCardinalTestFixture.linkUserCardinal(user3, cardinal7));
-		userCardinalRepository.flush();
+
 	}
 
 	@Test

--- a/src/test/java/leets/weeth/domain/user/domain/repository/UserRepositoryTest.java
+++ b/src/test/java/leets/weeth/domain/user/domain/repository/UserRepositoryTest.java
@@ -1,0 +1,72 @@
+package leets.weeth.domain.user.domain.repository;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import leets.weeth.config.TestContainersConfig;
+import leets.weeth.domain.user.domain.entity.Cardinal;
+import leets.weeth.domain.user.domain.entity.User;
+import leets.weeth.domain.user.domain.entity.UserCardinal;
+import leets.weeth.domain.user.domain.entity.enums.Status;
+import leets.weeth.domain.user.test.fixture.CardinalTestFixture;
+import leets.weeth.domain.user.test.fixture.UserCardinalTestFixture;
+import leets.weeth.domain.user.test.fixture.UserTestFixture;
+
+@DataJpaTest
+@Import(TestContainersConfig.class)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+public class UserRepositoryTest {
+
+	@Autowired
+	private UserRepository userRepository;
+
+	@Autowired
+	private UserCardinalRepository userCardinalRepository;
+
+	@Autowired
+	private CardinalRepository cardinalRepository;
+
+	private Cardinal cardinal7;
+	private Cardinal cardinal8;
+
+	@BeforeEach
+	void setUp() {
+
+		cardinal7 = cardinalRepository.save(CardinalTestFixture.createCardinal(7, 2026, 1));
+		cardinal8 = cardinalRepository.save(CardinalTestFixture.createCardinal(8, 2026, 2));
+
+		var user1 = userRepository.save(UserTestFixture.createActiveUser1());
+		var user2 = userRepository.save(UserTestFixture.createActiveUser2());
+		var user3 = userRepository.save(UserTestFixture.createWaitingUser1());
+
+		user1.accept();
+		user2.accept();
+
+		userCardinalRepository.save(UserCardinalTestFixture.linkUserCardinal(user1, cardinal7));
+		userCardinalRepository.save(UserCardinalTestFixture.linkUserCardinal(user2, cardinal8));
+		userCardinalRepository.save(UserCardinalTestFixture.linkUserCardinal(user3, cardinal7));
+		userCardinalRepository.flush();
+	}
+
+	@Test
+	@DisplayName("findAllByCardinalAndStatus(): 특정 기수 + 상태에 맞는 유저만 조회된다")
+	void findAllByCardinalAndStatus() {
+		// when
+		List<User> result = userRepository.findAllByCardinalAndStatus(cardinal7, Status.ACTIVE);
+
+		// then
+		assertThat(result)
+			.hasSize(1)
+			.extracting(User::getName)
+			.containsExactly("적순");
+	}
+}

--- a/src/test/java/leets/weeth/domain/user/domain/repository/UsesrCardinalRepositoryTest.java
+++ b/src/test/java/leets/weeth/domain/user/domain/repository/UsesrCardinalRepositoryTest.java
@@ -16,6 +16,8 @@ import leets.weeth.domain.user.domain.entity.Cardinal;
 import leets.weeth.domain.user.domain.entity.User;
 import leets.weeth.domain.user.domain.entity.UserCardinal;
 import leets.weeth.domain.user.domain.entity.enums.Status;
+import leets.weeth.domain.user.test.fixture.CardinalTestFixture;
+import leets.weeth.domain.user.test.fixture.UserTestFixture;
 
 @DataJpaTest
 @Import(TestContainersConfig.class)
@@ -34,32 +36,13 @@ public class UsesrCardinalRepositoryTest {
 	@Test
 	void 유저별_기수_내림차순_조회되는지() {
 		//given
-		User user = User.builder()
-			.email("test@test.com")
-			.name("문적순")
-			.status(Status.ACTIVE)
-			.build();
+		var user = UserTestFixture.createActiveUser1();
 
 		userRepository.save(user);
 
-		Cardinal cardinal1 = cardinalRepository.save(Cardinal.builder()
-			.cardinalNumber(5)
-			.year(2023)
-			.semester(1)
-			.build());
-
-		Cardinal cardinal2 = cardinalRepository.save(Cardinal.builder()
-			.cardinalNumber(6)
-			.year(2023)
-			.semester(2)
-			.build());
-
-		Cardinal cardinal3 = cardinalRepository.save(Cardinal.builder()
-			.cardinalNumber(7)
-			.year(2024)
-			.semester(1)
-			.build());
-
+		var cardinal1 = cardinalRepository.save(CardinalTestFixture.createCardinal(5,2023,1));
+		var cardinal2 = cardinalRepository.save(CardinalTestFixture.createCardinal(6,2023,2));
+		var cardinal3 = cardinalRepository.save(CardinalTestFixture.createCardinal(7,2024,1));
 
 		userCardinalRepository.saveAll(List.of(
 			new UserCardinal(user, cardinal1),
@@ -81,13 +64,16 @@ public class UsesrCardinalRepositoryTest {
 	@Test
 	void 여러_유저의_기수를_유저별_내림차순으로_조회한다() {
 		//given
-		User user1 = userRepository.save(User.builder().email("user1@test.com").name("적순").status(Status.ACTIVE).build());
-		User user2 = userRepository.save(User.builder().email("user2@test.com").name("순적").status(Status.ACTIVE).build());
+		var user1 = UserTestFixture.createActiveUser1();
+		var user2 = UserTestFixture.createActiveUser2();
 
-		Cardinal c1 = cardinalRepository.save(Cardinal.builder().cardinalNumber(5).year(2023).semester(1).build());
-		Cardinal c2 = cardinalRepository.save(Cardinal.builder().cardinalNumber(6).year(2023).semester(2).build());
-		Cardinal c3 = cardinalRepository.save(Cardinal.builder().cardinalNumber(7).year(2024).semester(1).build());
-		Cardinal c4 = cardinalRepository.save(Cardinal.builder().cardinalNumber(8).year(2024).semester(2).build());
+		userRepository.save(user1);
+		userRepository.save(user2);
+
+		var c1 = cardinalRepository.save(CardinalTestFixture.createCardinal(5,2023,1));
+		var c2 = cardinalRepository.save(CardinalTestFixture.createCardinal(6,2023,2));
+		var c3 = cardinalRepository.save(CardinalTestFixture.createCardinal(7,2024,1));
+		var c4 = cardinalRepository.save(CardinalTestFixture.createCardinal(8,2024,2));
 
 		userCardinalRepository.saveAll(List.of(
 			new UserCardinal(user1, c3),

--- a/src/test/java/leets/weeth/domain/user/domain/repository/UsesrCardinalRepositoryTest.java
+++ b/src/test/java/leets/weeth/domain/user/domain/repository/UsesrCardinalRepositoryTest.java
@@ -78,5 +78,39 @@ public class UsesrCardinalRepositoryTest {
 
 	}
 
+	@Test
+	void 여러_유저의_기수를_유저별_내림차순으로_조회한다() {
+		//given
+		User user1 = userRepository.save(User.builder().email("user1@test.com").name("적순").status(Status.ACTIVE).build());
+		User user2 = userRepository.save(User.builder().email("user2@test.com").name("순적").status(Status.ACTIVE).build());
+
+		Cardinal c1 = cardinalRepository.save(Cardinal.builder().cardinalNumber(5).year(2023).semester(1).build());
+		Cardinal c2 = cardinalRepository.save(Cardinal.builder().cardinalNumber(6).year(2023).semester(2).build());
+		Cardinal c3 = cardinalRepository.save(Cardinal.builder().cardinalNumber(7).year(2024).semester(1).build());
+		Cardinal c4 = cardinalRepository.save(Cardinal.builder().cardinalNumber(8).year(2024).semester(2).build());
+
+		userCardinalRepository.saveAll(List.of(
+			new UserCardinal(user1, c3),
+			new UserCardinal(user1, c2)
+		));
+		userCardinalRepository.saveAll(List.of(
+			new UserCardinal(user2, c4),
+			new UserCardinal(user2, c1)
+		));
+
+		//when
+		List<UserCardinal> result = userCardinalRepository.findAllByUsers(List.of(user1, user2));
+
+		//then
+		assertThat(result).hasSize(4);
+		assertThat(result.get(0).getUser().getId()).isEqualTo(user1.getId());
+		assertThat(result.get(0).getCardinal().getCardinalNumber()).isEqualTo(7);
+		assertThat(result.get(1).getCardinal().getCardinalNumber()).isEqualTo(6);
+
+		assertThat(result.get(2).getUser().getId()).isEqualTo(user2.getId());
+		assertThat(result.get(2).getCardinal().getCardinalNumber()).isEqualTo(8);
+		assertThat(result.get(3).getCardinal().getCardinalNumber()).isEqualTo(5);
+	}
+
 
 }

--- a/src/test/java/leets/weeth/domain/user/domain/repository/UsesrCardinalRepositoryTest.java
+++ b/src/test/java/leets/weeth/domain/user/domain/repository/UsesrCardinalRepositoryTest.java
@@ -1,0 +1,82 @@
+package leets.weeth.domain.user.domain.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import leets.weeth.config.TestContainersConfig;
+import leets.weeth.domain.user.domain.entity.Cardinal;
+import leets.weeth.domain.user.domain.entity.User;
+import leets.weeth.domain.user.domain.entity.UserCardinal;
+import leets.weeth.domain.user.domain.entity.enums.Status;
+
+@DataJpaTest
+@Import(TestContainersConfig.class)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+public class UsesrCardinalRepositoryTest {
+
+	@Autowired
+	UserRepository userRepository;
+
+	@Autowired
+	CardinalRepository cardinalRepository;
+
+	@Autowired
+	UserCardinalRepository userCardinalRepository;
+
+	@Test
+	void 유저별_기수_내림차순_조회되는지() {
+		//given
+		User user = User.builder()
+			.email("test@test.com")
+			.name("문적순")
+			.status(Status.ACTIVE)
+			.build();
+
+		userRepository.save(user);
+
+		Cardinal cardinal1 = cardinalRepository.save(Cardinal.builder()
+			.cardinalNumber(5)
+			.year(2023)
+			.semester(1)
+			.build());
+
+		Cardinal cardinal2 = cardinalRepository.save(Cardinal.builder()
+			.cardinalNumber(6)
+			.year(2023)
+			.semester(2)
+			.build());
+
+		Cardinal cardinal3 = cardinalRepository.save(Cardinal.builder()
+			.cardinalNumber(7)
+			.year(2024)
+			.semester(1)
+			.build());
+
+
+		userCardinalRepository.saveAll(List.of(
+			new UserCardinal(user, cardinal1),
+			new UserCardinal(user, cardinal2),
+			new UserCardinal(user, cardinal3)
+		));
+
+		//when
+		List<UserCardinal> result = userCardinalRepository.findAllByUserOrderByCardinalCardinalNumberDesc(user);
+
+		//then
+		assertThat(result).hasSize(3);
+		assertThat(result.get(0).getCardinal().getCardinalNumber()).isEqualTo(7);
+		assertThat(result.get(1).getCardinal().getCardinalNumber()).isEqualTo(6);
+		assertThat(result.get(2).getCardinal().getCardinalNumber()).isEqualTo(5);
+
+	}
+
+
+}

--- a/src/test/java/leets/weeth/domain/user/test/fixture/CardinalTestFixture.java
+++ b/src/test/java/leets/weeth/domain/user/test/fixture/CardinalTestFixture.java
@@ -5,40 +5,40 @@ import leets.weeth.domain.user.domain.entity.enums.CardinalStatus;
 
 public class CardinalTestFixture {
 
-	public static Cardinal createCardinal() {
+	public static Cardinal createCardinal(int cardinalNumber, int year, int semester) {
 		return Cardinal.builder()
-			.cardinalNumber(3)
-			.year(2024)
-			.semester(1)
+			.cardinalNumber(cardinalNumber)
+			.year(year)
+			.semester(semester)
 			.status(CardinalStatus.DONE)
 			.build();
 	}
 
-	public static Cardinal createCardinal(Long id) {
+	public static Cardinal createCardinal(Long id, int cardinalNumber, int year, int semester) {
 		return Cardinal.builder()
 			.id(id)
-			.cardinalNumber(3)
-			.year(2024)
-			.semester(1)
+			.cardinalNumber(cardinalNumber)
+			.year(year)
+			.semester(semester)
 			.status(CardinalStatus.DONE)
 			.build();
 	}
 
-	public static Cardinal createCardinalInProgress() {
+	public static Cardinal createCardinalInProgress ( int cardinalNumber, int year, int semester) {
 		return Cardinal.builder()
-			.cardinalNumber(3)
-			.year(2024)
-			.semester(1)
+			.cardinalNumber(cardinalNumber)
+			.year(year)
+			.semester(semester)
 			.status(CardinalStatus.IN_PROGRESS)
 			.build();
 	}
 
-	public static Cardinal createCardinalInProgress(Long id) {
+	public static Cardinal createCardinalInProgress(Long id, int cardinalNumber, int year, int semester) {
 		return Cardinal.builder()
 			.id(id)
-			.cardinalNumber(3)
-			.year(2024)
-			.semester(1)
+			.cardinalNumber(cardinalNumber)
+			.year(year)
+			.semester(semester)
 			.status(CardinalStatus.IN_PROGRESS)
 			.build();
 	}

--- a/src/test/java/leets/weeth/domain/user/test/fixture/CardinalTestFixture.java
+++ b/src/test/java/leets/weeth/domain/user/test/fixture/CardinalTestFixture.java
@@ -1,0 +1,45 @@
+package leets.weeth.domain.user.test.fixture;
+
+import leets.weeth.domain.user.domain.entity.Cardinal;
+import leets.weeth.domain.user.domain.entity.enums.CardinalStatus;
+
+public class CardinalTestFixture {
+
+	public static Cardinal createCardinal() {
+		return Cardinal.builder()
+			.cardinalNumber(3)
+			.year(2024)
+			.semester(1)
+			.status(CardinalStatus.DONE)
+			.build();
+	}
+
+	public static Cardinal createCardinal(Long id) {
+		return Cardinal.builder()
+			.id(id)
+			.cardinalNumber(3)
+			.year(2024)
+			.semester(1)
+			.status(CardinalStatus.DONE)
+			.build();
+	}
+
+	public static Cardinal createCardinalInProgress() {
+		return Cardinal.builder()
+			.cardinalNumber(3)
+			.year(2024)
+			.semester(1)
+			.status(CardinalStatus.IN_PROGRESS)
+			.build();
+	}
+
+	public static Cardinal createCardinalInProgress(Long id) {
+		return Cardinal.builder()
+			.id(id)
+			.cardinalNumber(3)
+			.year(2024)
+			.semester(1)
+			.status(CardinalStatus.IN_PROGRESS)
+			.build();
+	}
+}

--- a/src/test/java/leets/weeth/domain/user/test/fixture/UserCardinalTestFixture.java
+++ b/src/test/java/leets/weeth/domain/user/test/fixture/UserCardinalTestFixture.java
@@ -1,0 +1,12 @@
+package leets.weeth.domain.user.test.fixture;
+
+import leets.weeth.domain.user.domain.entity.Cardinal;
+import leets.weeth.domain.user.domain.entity.User;
+import leets.weeth.domain.user.domain.entity.UserCardinal;
+
+public class UserCardinalTestFixture {
+
+	public static UserCardinal linkUserCardinal(User user, Cardinal cardinal) {
+		return new UserCardinal(user, cardinal);
+	}
+}

--- a/src/test/java/leets/weeth/domain/user/test/fixture/UserTestFixture.java
+++ b/src/test/java/leets/weeth/domain/user/test/fixture/UserTestFixture.java
@@ -1,0 +1,43 @@
+package leets.weeth.domain.user.test.fixture;
+
+import leets.weeth.domain.user.domain.entity.User;
+import leets.weeth.domain.user.domain.entity.enums.Status;
+
+public class UserTestFixture {
+
+	public static User createActiveUser() {
+		return User.builder()
+			.name("적순")
+			.email("test1@test.com")
+			.status(Status.ACTIVE)
+			.build();
+	}
+
+	public static User createActiveUser(Long id) {
+		return User.builder()
+			.id(id)
+			.name("적순")
+			.email("test1@test.com")
+			.status(Status.ACTIVE)
+			.build();
+	}
+
+	public static User createWaitingUser() {
+		return User.builder()
+			.name("순적")
+			.email("test2@test.com")
+			.status(Status.WAITING)
+			.build();
+	}
+
+	public static User createWaitingUser(Long id) {
+		return User.builder()
+			.id(id)
+			.name("순적")
+			.email("test2@test.com")
+			.status(Status.WAITING)
+			.build();
+	}
+
+
+}

--- a/src/test/java/leets/weeth/domain/user/test/fixture/UserTestFixture.java
+++ b/src/test/java/leets/weeth/domain/user/test/fixture/UserTestFixture.java
@@ -33,7 +33,7 @@ public class UserTestFixture {
 	public static User createActiveUser2(Long id) {
 		return User.builder()
 			.id(id)
-			.name("적순")
+			.name("적순2")
 			.email("test2@test.com")
 			.status(Status.ACTIVE)
 			.build();

--- a/src/test/java/leets/weeth/domain/user/test/fixture/UserTestFixture.java
+++ b/src/test/java/leets/weeth/domain/user/test/fixture/UserTestFixture.java
@@ -5,7 +5,7 @@ import leets.weeth.domain.user.domain.entity.enums.Status;
 
 public class UserTestFixture {
 
-	public static User createActiveUser() {
+	public static User createActiveUser1() {
 		return User.builder()
 			.name("적순")
 			.email("test1@test.com")
@@ -13,7 +13,7 @@ public class UserTestFixture {
 			.build();
 	}
 
-	public static User createActiveUser(Long id) {
+	public static User createActiveUser1(Long id) {
 		return User.builder()
 			.id(id)
 			.name("적순")
@@ -22,7 +22,24 @@ public class UserTestFixture {
 			.build();
 	}
 
-	public static User createWaitingUser() {
+	public static User createActiveUser2() {
+		return User.builder()
+			.name("적순2")
+			.email("test2@test.com")
+			.status(Status.ACTIVE)
+			.build();
+	}
+
+	public static User createActiveUser2(Long id) {
+		return User.builder()
+			.id(id)
+			.name("적순")
+			.email("test2@test.com")
+			.status(Status.ACTIVE)
+			.build();
+	}
+
+	public static User createWaitingUser1() {
 		return User.builder()
 			.name("순적")
 			.email("test2@test.com")
@@ -30,7 +47,7 @@ public class UserTestFixture {
 			.build();
 	}
 
-	public static User createWaitingUser(Long id) {
+	public static User createWaitingUser1(Long id) {
 		return User.builder()
 			.id(id)
 			.name("순적")
@@ -39,5 +56,21 @@ public class UserTestFixture {
 			.build();
 	}
 
+	public static User createWaitingUser2() {
+		return User.builder()
+			.name("순적2")
+			.email("test3@test.com")
+			.status(Status.WAITING)
+			.build();
+	}
+
+	public static User createWaitingUser2(Long id) {
+		return User.builder()
+			.id(id)
+			.name("순적2")
+			.email("test3@test.com")
+			.status(Status.WAITING)
+			.build();
+	}
 
 }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,12 @@
+spring:
+  profiles:
+    active: test
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+        dialect: org.hibernate.dialect.MySQL8Dialect
+


### PR DESCRIPTION
## PR 내용
유저 도메인 단위 테스트 코드를 작성해가는 중입니다.
테스트 코드 작성이 처음이라 저만의 기준은 무엇인지 어떤 과정으로 작성하였고 작성할 것인지 적어보려합니다. 

## 1. 파일 구조 
파일 구조 같은 경우는 src 하위로 main과 동등하게 test 디렉토리를 만들어주었고
<img width="350" height="367" alt="스크린샷 2025-10-18 오후 4 59 49" src="https://github.com/user-attachments/assets/4faaecb0-7ebe-44f3-b674-abd4b7dbbccd" />
작성하고자하는 파일명뒤에test만 붙여서 파일명 네이밍 하였습니다.
(* → 이렇게 위치를 맞추면 테스트 클래스가 IDE에서 자동으로 연결된다고 합니다)

## 2. 테스트 기준
unit 단위의 테스트는 저는 비즈니스 로직 하나하나를 기준으로 삼기로 했습니다. 양이 많기는 한데 할 수 있는 만큼 짜보면서 감을 찾아가려합니다.

### 2.1 외부 의존이 적은 파일 기준
저 같은 경우 User를 담당하게 됐는데 저희 아키텍처가 DDD라 비즈니스 로직이 UseCase와 Service에 몰려있습니다. 파일을 차근차근 보니

CardinalUseCase – 저장/업데이트 시 “진행중(inProgress) 상태 관리”가 핵심. (의존성 3개, 분기 단순) => 요걸로 먼저하기로 했습니다.

## 3. 설계
이제 테스트 코드를 어떻게 설계하고 검증 목표가 무엇인지를 생각해보았습니다.
1. CardinalUseCase 에 존재하는 메소드들을 검증하자 
2.  기존 메소드들이 어떤 로직이고 어떻게 되야하는지를 철저히 알아야한다 
3. 로직을 생각하면서 위험 지점이 어디인가를 판단 (여기가 잘못돌아가면 에러가 터진다 같은 ..) 

### Save() 예시 
기수를 저장하는 save() 메소드를 분석해보았습니다.

```
@Transactional
public void save(CardinalSaveRequest dto) {
    cardinalGetService.validateCardinal(dto.cardinalNumber());

    Cardinal cardinal = cardinalSaveService.save(cardinalMapper.from(dto));

    if (dto.inProgress()) {
        updateCardinalStatus(cardinal);
    }
}
```

getService에서 요청하는 dto의 기수가 유효한지 검증한뒤 ,  매퍼를 통해 기수를 저장한다 . 그리고 기수 진행상태도 저장한다 .
즉 유효성 검사 -> 기수 저장 -> 상태 갱신(진행중) 

우선 요청으로  진행중/ 진행중 아닌 기수 등록 요청 2가지 경우가 올 수 있다고 판단했습니다.
-> 유효성 검사는 두 가지 경우 둘 다 호출 되어야한다.
-> 기수 저장도 호출 되어야한다
-> 상태 변경 로직은 현재 진행중인 기수가 요청이 들어와야지만 실행되어야한다.

TMI) 진행중이 아닌기수 (1-5기 및 미래 기수) -> 기수 상태에 READY(미래 기수를 위한)도 추가하는게 어떤가 싶네요


Given 
기수 검증, 매퍼, 저장 서비스가 이렇게 동작한다고 가정했을 때
When
 useCase.save(request)를 실행하면
Then 
검증(validateCardinal)과 저장(save)은 반드시 호출되어야 하고 진행중 상태 변경(findInProgress)은 호출되면 안 된다.

이렇게 작성해보았습니다.  음 우선 메소드 하나만 작성하였고 
Given-When-Then 패턴을 쉽게 이해하기 위해 메서드명_상황_예상결과로  테스트 메서드 네이밍하였습니다.

+첨언 

update() 메서드는 원래 학기와 연도 정보를 수정하기 위한 용도라고 생각됩니다
```
@Transactional
    public void update(CardinalUpdateRequest dto) {
        Cardinal cardinal = cardinalGetService.findById(dto.id());

        cardinal.update(dto);

        if (dto.inProgress()) {
            updateCardinalStatus(cardinal);
        }
    }
```
하지만 내부를 보면 if (dto.inProgress()) 조건문을 통해
기수를 진행중으로 전환하는 로직(updateCardinalStatus) 도 함께 수행하고 있습니다.
updateCardinalStatus()는 현재 진행중(IN_PROGRESS)인 기수를 모두 찾아
상태를 DONE으로 바꾼 뒤, 현재 수정 중인 기수만 IN_PROGRESS로 설정하는 로직인데,
따라서 현재 update()는 단순 정보 수정(연도, 학기 변경)과 상태 전환(활성화)이라는
두 가지 책임을 동시에 가지고 있는 구조라고 판단됩니다.
이에 따라 책임 분리가 필요하며, 테스트 또한 목적에 따라 나누기로 했습니다.
update() 테스트에서는 연도와 학기만 변경되는지를 검증하고 
기수를 활성화(상태 전환)하는 로직은 별도의 메서드로 분리하여 독립적으로 테스트하겠습니다. (추후 리팩토링)


<br>

## PR 세부사항

<br>

## 관련 스크린샷

<img width="348" height="153" alt="스크린샷 2025-10-18 오후 8 54 57" src="https://github.com/user-attachments/assets/e2037b3c-d83c-4720-b14b-00e8e3864e46" />



<br>

## 주의사항

이런식으로 진행하는 것이 올바른 설계인지 여쭤보고 싶고 , 첨언이나 조언도 언제나 환영입니다.

<br>

## 체크 리스트

- [x] 리뷰어 설정
- [x] Assignee 설정
- [ ] Label 설정
- [ ] 제목 양식 맞췄나요? (ex. #0 Feat: 기능 추가)
- [ ] 변경 사항에 대한 테스트

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * 사용자 관리 및 기수 관리에 대한 포괄적인 단위 테스트 대거 추가(업무 흐름·검증·상태 전환 등 시나리오 포함)
  * 리포지토리 계층의 JPA 통합 테스트 추가(데이터 조회·정렬·연관관계 검증)
  * Testcontainers 기반 통합 테스트 및 전용 테스트 프로파일 추가
  * 테스트용 픽스처·헬퍼 추가로 테스트 작성·유지 보수 개선
  * JUnit5 및 테스트 관련 의존성 확대로 테스트 인프라 강화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->