### PR TITLE
[WTH-49] weeth 게시글 생성시 게시글 id 보내주도록 수정

### DIFF
--- a/src/main/java/leets/weeth/domain/board/application/dto/NoticeDTO.java
+++ b/src/main/java/leets/weeth/domain/board/application/dto/NoticeDTO.java
@@ -1,5 +1,6 @@
 package leets.weeth.domain.board.application.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import leets.weeth.domain.comment.application.dto.CommentDTO;
@@ -56,6 +57,13 @@ public class NoticeDTO {
             LocalDateTime time,//modifiedAt
             Integer commentCount,
             boolean hasFile
+    ) {
+    }
+
+    @Builder
+    public record SaveResponse(
+            @Schema(description = "공지사항 생성 응답", example = "1")
+            long id
     ) {
     }
 

--- a/src/main/java/leets/weeth/domain/board/application/dto/PostDTO.java
+++ b/src/main/java/leets/weeth/domain/board/application/dto/PostDTO.java
@@ -1,10 +1,9 @@
 package leets.weeth.domain.board.application.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import java.time.LocalDateTime;
-import java.util.List;
 import leets.weeth.domain.board.domain.entity.enums.Category;
 import leets.weeth.domain.board.domain.entity.enums.Part;
 import leets.weeth.domain.comment.application.dto.CommentDTO;
@@ -13,6 +12,9 @@ import leets.weeth.domain.file.application.dto.response.FileResponse;
 import leets.weeth.domain.user.domain.entity.enums.Position;
 import leets.weeth.domain.user.domain.entity.enums.Role;
 import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 public class PostDTO {
 
@@ -26,7 +28,8 @@ public class PostDTO {
             @NotNull Part part,
             @NotNull Integer cardinalNumber,
             @Valid List<@NotNull FileSaveRequest> files
-    ){}
+    ) {
+    }
 
     @Builder
     public record SaveEducation(
@@ -35,7 +38,15 @@ public class PostDTO {
             @NotNull List<Part> parts,
             @NotNull Integer cardinalNumber,
             @Valid List<@NotNull FileSaveRequest> files
-    ){}
+    ) {
+    }
+
+    @Builder
+    public record SaveResponse(
+            @Schema(description = "게시글 생성시 응답", example = "1")
+            long id
+    ) {
+    }
 
     @Builder
     public record Update(
@@ -46,7 +57,8 @@ public class PostDTO {
             Part part,
             Integer cardinalNumber,
             @Valid List<FileSaveRequest> files
-    ){}
+    ) {
+    }
 
     @Builder
     public record UpdateEducation(
@@ -55,7 +67,8 @@ public class PostDTO {
             List<Part> parts,
             Integer cardinalNumber,
             @Valid List<FileSaveRequest> files
-    ){}
+    ) {
+    }
 
     @Builder
     public record Response(
@@ -74,7 +87,8 @@ public class PostDTO {
             Integer commentCount,
             List<CommentDTO.Response> comments,
             List<FileResponse> fileUrls
-    ){}
+    ) {
+    }
 
     @Builder
     public record ResponseAll(
@@ -91,7 +105,8 @@ public class PostDTO {
             Integer commentCount,
             boolean hasFile,
             boolean isNew
-    ){}
+    ) {
+    }
 
     @Builder
     public record ResponseEducationAll(
@@ -106,9 +121,11 @@ public class PostDTO {
             Integer commentCount,
             boolean hasFile,
             boolean isNew
-    ){}
+    ) {
+    }
 
     public record ResponseStudyNames(
             List<String> studyNames
-    ) {}
+    ) {
+    }
 }

--- a/src/main/java/leets/weeth/domain/board/application/mapper/NoticeMapper.java
+++ b/src/main/java/leets/weeth/domain/board/application/mapper/NoticeMapper.java
@@ -37,4 +37,6 @@ public interface NoticeMapper {
     })
     NoticeDTO.Response toNoticeDto(Notice notice, List<FileResponse> fileUrls, List<CommentDTO.Response> comments);
 
+    NoticeDTO.SaveResponse  toSaveResponse(Notice notice);
+
 }

--- a/src/main/java/leets/weeth/domain/board/application/mapper/PostMapper.java
+++ b/src/main/java/leets/weeth/domain/board/application/mapper/PostMapper.java
@@ -34,6 +34,8 @@ public interface PostMapper {
     @Mapping(target = "category", constant = "Education")
     Post fromEducationDto(PostDTO.SaveEducation dto, User user);
 
+    PostDTO.SaveResponse toSaveResponse(Post post);
+
     @Mappings({
             @Mapping(target = "name", source = "post.user.name"),
             @Mapping(target = "position", source = "post.user.position"),

--- a/src/main/java/leets/weeth/domain/board/application/usecase/NoticeUsecase.java
+++ b/src/main/java/leets/weeth/domain/board/application/usecase/NoticeUsecase.java
@@ -6,14 +6,13 @@ import org.springframework.data.domain.Slice;
 
 
 public interface NoticeUsecase {
-
-    void save(NoticeDTO.Save dto, Long userId);
+    NoticeDTO.SaveResponse save(NoticeDTO.Save dto, Long userId);
 
     NoticeDTO.Response findNotice(Long noticeId);
 
     Slice<NoticeDTO.ResponseAll> findNotices(int pageNumber, int pageSize);
 
-    void update(Long noticeId, NoticeDTO.Update dto, Long userId) throws UserNotMatchException;
+    NoticeDTO.SaveResponse update(Long noticeId, NoticeDTO.Update dto, Long userId) throws UserNotMatchException;
 
     void delete(Long noticeId, Long userId) throws UserNotMatchException;
 

--- a/src/main/java/leets/weeth/domain/board/application/usecase/NoticeUsecaseImpl.java
+++ b/src/main/java/leets/weeth/domain/board/application/usecase/NoticeUsecaseImpl.java
@@ -1,9 +1,5 @@
 package leets.weeth.domain.board.application.usecase;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 import leets.weeth.domain.board.application.dto.NoticeDTO;
 import leets.weeth.domain.board.application.exception.NoSearchResultException;
 import leets.weeth.domain.board.application.exception.PageNotFoundException;
@@ -33,6 +29,11 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 @Service
 @RequiredArgsConstructor
 public class NoticeUsecaseImpl implements NoticeUsecase {
@@ -54,14 +55,16 @@ public class NoticeUsecaseImpl implements NoticeUsecase {
 
     @Override
     @Transactional
-    public void save(NoticeDTO.Save request, Long userId) {
+    public NoticeDTO.SaveResponse save(NoticeDTO.Save request, Long userId) {
         User user = userGetService.find(userId);
 
         Notice notice = mapper.fromNoticeDto(request, user);
-        noticeSaveService.save(notice);
+        Notice savedNotice = noticeSaveService.save(notice);
 
         List<File> files = fileMapper.toFileList(request.files(), notice);
         fileSaveService.save(files);
+
+        return mapper.toSaveResponse(savedNotice);
     }
 
     @Override
@@ -103,7 +106,7 @@ public class NoticeUsecaseImpl implements NoticeUsecase {
 
     @Override
     @Transactional
-    public void update(Long noticeId, NoticeDTO.Update dto, Long userId) {
+    public NoticeDTO.SaveResponse update(Long noticeId, NoticeDTO.Update dto, Long userId) {
         Notice notice = validateOwner(noticeId, userId);
 
         List<File> fileList = getFiles(noticeId);
@@ -113,6 +116,8 @@ public class NoticeUsecaseImpl implements NoticeUsecase {
         fileSaveService.save(files);
 
         noticeUpdateService.update(notice, dto);
+
+        return mapper.toSaveResponse(notice);
     }
 
     @Override

--- a/src/main/java/leets/weeth/domain/board/application/usecase/PostUsecase.java
+++ b/src/main/java/leets/weeth/domain/board/application/usecase/PostUsecase.java
@@ -9,9 +9,9 @@ import org.springframework.data.domain.Slice;
 
 public interface PostUsecase {
 
-    void save(PostDTO.Save request, Long userId);
+    PostDTO.SaveResponse save(PostDTO.Save request, Long userId);
 
-    void saveEducation(PostDTO.SaveEducation request, Long userId);
+    PostDTO.SaveResponse saveEducation(PostDTO.SaveEducation request, Long userId);
 
     PostDTO.Response findPost(Long postId);
 
@@ -23,9 +23,9 @@ public interface PostUsecase {
 
     PostDTO.ResponseStudyNames findStudyNames(Part part);
 
-    void update(Long postId, PostDTO.Update dto, Long userId) throws UserNotMatchException;
+    PostDTO.SaveResponse update(Long postId, PostDTO.Update dto, Long userId) throws UserNotMatchException;
 
-    void updateEducation(Long postId, PostDTO.UpdateEducation dto, Long userId) throws UserNotMatchException;
+    PostDTO.SaveResponse updateEducation(Long postId, PostDTO.UpdateEducation dto, Long userId) throws UserNotMatchException;
 
     void delete(Long postId, Long userId) throws UserNotMatchException;
 

--- a/src/main/java/leets/weeth/domain/board/domain/service/NoticeSaveService.java
+++ b/src/main/java/leets/weeth/domain/board/domain/service/NoticeSaveService.java
@@ -1,6 +1,5 @@
 package leets.weeth.domain.board.domain.service;
 
-import jakarta.transaction.Transactional;
 import leets.weeth.domain.board.domain.entity.Notice;
 import leets.weeth.domain.board.domain.repository.NoticeRepository;
 import lombok.RequiredArgsConstructor;
@@ -12,8 +11,8 @@ public class NoticeSaveService {
 
     private final NoticeRepository noticeRepository;
 
-    public void save(Notice notice){
-        noticeRepository.save(notice);
+    public Notice save(Notice notice){
+        return noticeRepository.save(notice);
     }
 
 }

--- a/src/main/java/leets/weeth/domain/board/domain/service/PostSaveService.java
+++ b/src/main/java/leets/weeth/domain/board/domain/service/PostSaveService.java
@@ -1,6 +1,5 @@
 package leets.weeth.domain.board.domain.service;
 
-import jakarta.transaction.Transactional;
 import leets.weeth.domain.board.domain.entity.Post;
 import leets.weeth.domain.board.domain.repository.PostRepository;
 import lombok.RequiredArgsConstructor;
@@ -12,8 +11,7 @@ public class PostSaveService {
 
     private final PostRepository postRepository;
 
-    public void save(Post post) {
-        postRepository.save(post);
+    public Post save(Post post) {
+        return postRepository.save(post);
     }
-
 }

--- a/src/main/java/leets/weeth/domain/board/presentation/EducationAdminController.java
+++ b/src/main/java/leets/weeth/domain/board/presentation/EducationAdminController.java
@@ -1,8 +1,5 @@
 package leets.weeth.domain.board.presentation;
 
-import static leets.weeth.domain.board.presentation.ResponseMessage.EDUCATION_UPDATED_SUCCESS;
-import static leets.weeth.domain.board.presentation.ResponseMessage.POST_CREATED_SUCCESS;
-
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -13,12 +10,10 @@ import leets.weeth.domain.user.application.exception.UserNotMatchException;
 import leets.weeth.global.auth.annotation.CurrentUser;
 import leets.weeth.global.common.response.CommonResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import static leets.weeth.domain.board.presentation.ResponseMessage.EDUCATION_UPDATED_SUCCESS;
+import static leets.weeth.domain.board.presentation.ResponseMessage.POST_CREATED_SUCCESS;
 
 @Tag(name = "EDUCATION ADMIN", description = "[ADMIN] 공지사항 교육자료 API")
 @RestController
@@ -29,18 +24,19 @@ public class EducationAdminController {
 
     @PostMapping("/education")
     @Operation(summary = "교육자료 생성")
-    public CommonResponse<String> saveEducation(@RequestBody @Valid PostDTO.SaveEducation dto, @Parameter(hidden = true) @CurrentUser Long userId) {
-        postUsecase.saveEducation(dto, userId);
+    public CommonResponse<PostDTO.SaveResponse> saveEducation(@RequestBody @Valid PostDTO.SaveEducation dto, @Parameter(hidden = true) @CurrentUser Long userId) {
+        PostDTO.SaveResponse response = postUsecase.saveEducation(dto, userId);
 
-        return CommonResponse.createSuccess(POST_CREATED_SUCCESS.getMessage());
+        return CommonResponse.createSuccess(POST_CREATED_SUCCESS.getMessage(), response);
     }
 
     @PatchMapping(value = "/{boardId}")
     @Operation(summary="교육자료 게시글 수정")
-    public CommonResponse<String> update(@PathVariable Long boardId,
+    public CommonResponse<PostDTO.SaveResponse> update(@PathVariable Long boardId,
                                          @RequestBody @Valid PostDTO.UpdateEducation dto,
                                          @Parameter(hidden = true) @CurrentUser Long userId) throws UserNotMatchException {
-        postUsecase.updateEducation(boardId, dto, userId);
-        return CommonResponse.createSuccess(EDUCATION_UPDATED_SUCCESS.getMessage());
+        PostDTO.SaveResponse response = postUsecase.updateEducation(boardId, dto, userId);
+
+        return CommonResponse.createSuccess(EDUCATION_UPDATED_SUCCESS.getMessage(), response);
     }
 }

--- a/src/main/java/leets/weeth/domain/board/presentation/NoticeAdminController.java
+++ b/src/main/java/leets/weeth/domain/board/presentation/NoticeAdminController.java
@@ -6,15 +6,11 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import leets.weeth.domain.board.application.dto.NoticeDTO;
 import leets.weeth.domain.board.application.usecase.NoticeUsecase;
-import leets.weeth.global.auth.annotation.CurrentUser;
 import leets.weeth.domain.user.application.exception.UserNotMatchException;
+import leets.weeth.global.auth.annotation.CurrentUser;
 import leets.weeth.global.common.response.CommonResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
-
-import java.util.List;
 
 import static leets.weeth.domain.board.presentation.ResponseMessage.*;
 
@@ -28,19 +24,21 @@ public class NoticeAdminController {
 
     @PostMapping
     @Operation(summary="공지사항 생성")
-    public CommonResponse<String> save(@RequestBody @Valid NoticeDTO.Save dto,
+    public CommonResponse<NoticeDTO.SaveResponse> save(@RequestBody @Valid NoticeDTO.Save dto,
                                        @Parameter(hidden = true) @CurrentUser Long userId) {
-        noticeUsecase.save(dto, userId);
-        return CommonResponse.createSuccess(NOTICE_CREATED_SUCCESS.getMessage());
+        NoticeDTO.SaveResponse response  = noticeUsecase.save(dto, userId);
+
+        return CommonResponse.createSuccess(NOTICE_CREATED_SUCCESS.getMessage(), response);
     }
 
     @PatchMapping(value = "/{noticeId}")
     @Operation(summary="특정 공지사항 수정")
-    public CommonResponse<String> update(@PathVariable Long noticeId,
+    public CommonResponse<NoticeDTO.SaveResponse> update(@PathVariable Long noticeId,
                                          @RequestBody @Valid NoticeDTO.Update dto,
                                          @Parameter(hidden = true) @CurrentUser Long userId) throws UserNotMatchException {
-        noticeUsecase.update(noticeId, dto, userId);
-        return CommonResponse.createSuccess(NOTICE_UPDATED_SUCCESS.getMessage());
+        NoticeDTO.SaveResponse response = noticeUsecase.update(noticeId, dto, userId);
+
+        return CommonResponse.createSuccess(NOTICE_UPDATED_SUCCESS.getMessage(), response);
     }
 
     @DeleteMapping("/{noticeId}")

--- a/src/main/java/leets/weeth/domain/board/presentation/PostController.java
+++ b/src/main/java/leets/weeth/domain/board/presentation/PostController.java
@@ -1,15 +1,5 @@
 package leets.weeth.domain.board.presentation;
 
-import static leets.weeth.domain.board.presentation.ResponseMessage.EDUCATION_SEARCH_SUCCESS;
-import static leets.weeth.domain.board.presentation.ResponseMessage.POST_CREATED_SUCCESS;
-import static leets.weeth.domain.board.presentation.ResponseMessage.POST_DELETED_SUCCESS;
-import static leets.weeth.domain.board.presentation.ResponseMessage.POST_EDU_FIND_SUCCESS;
-import static leets.weeth.domain.board.presentation.ResponseMessage.POST_FIND_ALL_SUCCESS;
-import static leets.weeth.domain.board.presentation.ResponseMessage.POST_FIND_BY_ID_SUCCESS;
-import static leets.weeth.domain.board.presentation.ResponseMessage.POST_PART_FIND_ALL_SUCCESS;
-import static leets.weeth.domain.board.presentation.ResponseMessage.POST_SEARCH_SUCCESS;
-import static leets.weeth.domain.board.presentation.ResponseMessage.POST_UPDATED_SUCCESS;
-
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -23,16 +13,9 @@ import leets.weeth.global.auth.annotation.CurrentUser;
 import leets.weeth.global.common.response.CommonResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Slice;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import static leets.weeth.domain.board.presentation.ResponseMessage.*;
 
 @Tag(name = "BOARD", description = "게시판 API")
 @RestController
@@ -44,10 +27,10 @@ public class PostController {
 
     @PostMapping
     @Operation(summary="파트 게시글 생성 (스터디 로그, 아티클)")
-    public CommonResponse<String> save(@RequestBody @Valid PostDTO.Save dto, @Parameter(hidden = true) @CurrentUser Long userId) {
-        postUsecase.save(dto, userId);
+    public CommonResponse<PostDTO.SaveResponse> save(@RequestBody @Valid PostDTO.Save dto, @Parameter(hidden = true) @CurrentUser Long userId) {
+        PostDTO.SaveResponse response = postUsecase.save(dto, userId);
 
-        return CommonResponse.createSuccess(POST_CREATED_SUCCESS.getMessage());
+        return CommonResponse.createSuccess(POST_CREATED_SUCCESS.getMessage(),  response);
     }
 
     @GetMapping
@@ -101,11 +84,12 @@ public class PostController {
 
     @PatchMapping(value = "/{boardId}/part")
     @Operation(summary="파트 게시글 수정")
-    public CommonResponse<String> update(@PathVariable Long boardId,
+    public CommonResponse<PostDTO.SaveResponse> update(@PathVariable Long boardId,
                                          @RequestBody @Valid PostDTO.Update dto,
                                          @Parameter(hidden = true) @CurrentUser Long userId) throws UserNotMatchException {
-        postUsecase.update(boardId, dto, userId);
-        return CommonResponse.createSuccess(POST_UPDATED_SUCCESS.getMessage());
+        PostDTO.SaveResponse response = postUsecase.update(boardId, dto, userId);
+
+        return CommonResponse.createSuccess(POST_UPDATED_SUCCESS.getMessage(), response);
     }
 
     @DeleteMapping("/{boardId}")

--- a/src/test/java/leets/weeth/domain/board/application/mapper/PostMapperTest.java
+++ b/src/test/java/leets/weeth/domain/board/application/mapper/PostMapperTest.java
@@ -1,0 +1,56 @@
+package leets.weeth.domain.board.application.mapper;
+
+import leets.weeth.domain.board.application.dto.PostDTO;
+import leets.weeth.domain.board.domain.entity.Post;
+import leets.weeth.domain.user.domain.entity.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mapstruct.factory.Mappers;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+class PostMapperTest {
+
+    @InjectMocks
+    private PostMapper mapper = Mappers.getMapper(PostMapper.class);
+
+    private User testUser;
+    private Post testPost;
+
+    @BeforeEach
+    void setUp() {
+        testUser = User.builder()
+                .id(1L)
+                .name("테스트유저")
+                .email("test@weeth.com")
+                .build();
+
+        testPost = Post.builder()
+                .id(1L)
+                .title("테스트 게시글")
+                .user(testUser)
+                .content("테스트 내용입니다.")
+                .user(testUser)
+                .build();
+    }
+
+    @Test
+    @DisplayName("Post를 PostDTO.SaveResponse로 변환")
+    void toSaveResponse() {
+        // given
+        // testPost 사용
+
+        // when
+        PostDTO.SaveResponse response = mapper.toSaveResponse(testPost);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.id()).isEqualTo(testPost.getId());
+    }
+
+}

--- a/src/test/java/leets/weeth/domain/board/application/mapper/PostMapperTest.java
+++ b/src/test/java/leets/weeth/domain/board/application/mapper/PostMapperTest.java
@@ -35,7 +35,6 @@ class PostMapperTest {
                 .title("테스트 게시글")
                 .user(testUser)
                 .content("테스트 내용입니다.")
-                .user(testUser)
                 .build();
     }
 


### PR DESCRIPTION
## PR 내용
- 게시글 생성/수정 시 프론트에서 바로 해당 게시글로 라우팅 하기 위해 response 값을 추가했습니다.

<br>

## PR 세부사항
- 일부 dto의 코드 컨벤션을 수정했습니다
- 스웨거 예시 응답을 추가했습니다.
- 검증할 내용이 크게 없어보여 mapper만 테스트 코드를 작성했습니다.
- 응답은 다음과 같습니다
```
{
  "code": 200,
  "message": "파트 게시글이 성공적으로 생성되었습니다.",
  "data": {
    "id": 1
  }
}
```
<br>

## 관련 스크린샷

<br>

## 주의사항
- 앞으로 API를 수정하거나 추가하는 경우 leenk와 동일하게 swagger hint를 추가해주세요
<br>

## 체크 리스트

- [x] 리뷰어 설정
- [x] Assignee 설정
- [x] Label 설정
- [x] 제목 양식 맞췄나요? (ex. #0 Feat: 기능 추가)
- [x] 변경 사항에 대한 테스트

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 게시글 및 공지사항 생성·수정 API가 생성된 항목의 ID를 포함한 구조화된 응답(SaveResponse)을 반환하도록 변경되었습니다.
  * 관리자·일반 API 응답이 단순 문자열에서 응답 페이로드를 포함하도록 일관화되었습니다.

* **Tests**
  * 매퍼의 SaveResponse 변환을 검증하는 단위 테스트를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->