### PR TITLE
[WTH-40] 캘린터 테스트 코드 작성 (Repository, Service)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,11 @@ dependencies {
 
 	// Test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation "org.junit.jupiter:junit-jupiter:5.8.1"
+	testImplementation "org.testcontainers:testcontainers:2.0.1"
+	testImplementation "org.testcontainers:testcontainers-junit-jupiter:2.0.1"
+	testImplementation "org.testcontainers:testcontainers-mysql:2.0.1"
+	testImplementation 'org.springframework.boot:spring-boot-testcontainers'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
 	// Swagger

--- a/src/test/java/leets/weeth/config/TestContainersConfig.java
+++ b/src/test/java/leets/weeth/config/TestContainersConfig.java
@@ -1,0 +1,19 @@
+package leets.weeth.config;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Bean;
+import org.testcontainers.mysql.MySQLContainer;
+import org.testcontainers.utility.DockerImageName;
+
+@TestConfiguration
+public class TestContainersConfig {
+    private static final String MYSQL_IMAGE = "mysql:8.0.41";
+
+    @Bean
+    @ServiceConnection
+    public MySQLContainer mysqlContainer() {
+        return new MySQLContainer(DockerImageName.parse(MYSQL_IMAGE))
+                .withReuse(true);
+    }
+}

--- a/src/test/java/leets/weeth/config/TestContainersTest.java
+++ b/src/test/java/leets/weeth/config/TestContainersTest.java
@@ -1,0 +1,25 @@
+package leets.weeth.config;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.testcontainers.mysql.MySQLContainer;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+@DataJpaTest
+@Import(TestContainersConfig.class)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class TestContainersTest {
+    @Autowired
+    private MySQLContainer mysqlContainer;
+
+    @Test
+    void 설정파일로_주입된_컨테이너_정상_동작_테스트() {
+        assertThat(mysqlContainer).isNotNull();
+        assertThat(mysqlContainer.isRunning()).isTrue();
+        System.out.println("Container JDBC URL: " + mysqlContainer.getJdbcUrl());
+    }
+}

--- a/src/test/java/leets/weeth/domain/schedule/domain/repository/EventRepositoryTest.java
+++ b/src/test/java/leets/weeth/domain/schedule/domain/repository/EventRepositoryTest.java
@@ -1,0 +1,82 @@
+package leets.weeth.domain.schedule.domain.repository;
+
+import leets.weeth.config.TestContainersConfig;
+import leets.weeth.domain.schedule.domain.entity.Event;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Import(TestContainersConfig.class)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class EventRepositoryTest {
+
+    @Autowired
+    private EventRepository eventRepository;
+
+    @BeforeEach
+    void setUp() {
+        LocalDateTime now = LocalDateTime.now();
+        Event event1 = Event.builder()
+                .title("Event 1")
+                .start(now.plusDays(1))
+                .end(now.plusDays(2))
+                .cardinal(1)
+                .build();
+
+        Event event2 = Event.builder()
+                .title("Event 2")
+                .start(now.plusDays(3))
+                .end(now.plusDays(4))
+                .cardinal(1)
+                .build();
+
+        Event event3 = Event.builder()
+                .title("Event 3")
+                .start(now.plusDays(5))
+                .end(now.plusDays(6))
+                .cardinal(2)
+                .build();
+
+        eventRepository.saveAll(List.of(event1, event2, event3));
+    }
+
+    @Test
+    void testFindByStartLessThanEqualAndEndGreaterThanEqualOrderByStartAsc() {
+        // given
+        LocalDateTime start = LocalDateTime.now().plusDays(2);
+        LocalDateTime end = LocalDateTime.now().plusDays(7);
+
+        // when
+        List<Event> events = eventRepository.findByStartLessThanEqualAndEndGreaterThanEqualOrderByStartAsc(end, start);
+
+        // then
+        assertThat(events)
+                .hasSize(2)
+                .extracting(Event::getTitle)
+                .containsExactly("Event 2", "Event 3"); // 순서와 구성이 모두 일치하는지
+    }
+
+    @Test
+    void testFindAllByCardinal() {
+        // given
+        int cardinal = 1;
+
+        // when
+        List<Event> events = eventRepository.findAllByCardinal(cardinal);
+
+        // then
+        assertThat(events)
+                .hasSize(2)
+                .extracting(Event::getTitle)
+                .containsExactly("Event 1", "Event 2");
+    }
+}

--- a/src/test/java/leets/weeth/domain/schedule/domain/repository/MeetingRepositoryTest.java
+++ b/src/test/java/leets/weeth/domain/schedule/domain/repository/MeetingRepositoryTest.java
@@ -1,0 +1,150 @@
+package leets.weeth.domain.schedule.domain.repository;
+
+import leets.weeth.config.TestContainersConfig;
+import leets.weeth.domain.schedule.domain.entity.Meeting;
+import leets.weeth.domain.schedule.domain.entity.enums.MeetingStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Import(TestContainersConfig.class)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class MeetingRepositoryTest {
+    @Autowired
+    private MeetingRepository meetingRepository;
+
+    @BeforeEach
+    void setUp() {
+        Meeting meeting1 = Meeting.builder()
+                .title("Meeting 1")
+                .start(LocalDateTime.now().plusDays(1))
+                .end(LocalDateTime.now().plusDays(2))
+                .code(1111)
+                .cardinal(1)
+                .meetingStatus(MeetingStatus.OPEN)
+                .build();
+
+        Meeting meeting2 = Meeting.builder()
+                .title("Meeting 2")
+                .start(LocalDateTime.now().plusDays(3))
+                .end(LocalDateTime.now().plusDays(4))
+                .code(2222)
+                .cardinal(1)
+                .meetingStatus(MeetingStatus.OPEN)
+                .build();
+
+        Meeting meeting3 = Meeting.builder()
+                .title("Meeting 3")
+                .start(LocalDateTime.now().plusDays(5))
+                .end(LocalDateTime.now().plusDays(6))
+                .code(3333)
+                .cardinal(2)
+                .meetingStatus(MeetingStatus.CLOSE)
+                .build();
+
+        meetingRepository.saveAll(java.util.List.of(meeting1, meeting2, meeting3));
+    }
+
+
+    @Test
+    void findByStartLessThanEqualAndEndGreaterThanEqualOrderByStartAsc() {
+        // given
+        LocalDateTime start = LocalDateTime.now().plusDays(1);
+        LocalDateTime end = LocalDateTime.now().plusDays(4);
+
+        // when
+        List<Meeting> meetings = meetingRepository.findByStartLessThanEqualAndEndGreaterThanEqualOrderByStartAsc(end, start);
+
+        // then
+        assertThat(meetings)
+                .hasSize(2)
+                .extracting(Meeting::getTitle)
+                .containsExactly("Meeting 1", "Meeting 2");
+    }
+
+    @Test
+    void findAllByCardinalOrderByStartAsc() {
+        // given
+        int cardinal = 1;
+
+        // when
+        List<Meeting> meetings = meetingRepository.findAllByCardinalOrderByStartAsc(cardinal);
+
+        // then
+        assertThat(meetings)
+                .hasSize(2)
+                .extracting(Meeting::getTitle)
+                .containsExactly("Meeting 1", "Meeting 2");
+    }
+
+    @Test
+    void findAllByCardinalOrderByStartDesc() {
+        // given
+        int cardinal = 1;
+
+        // when
+        List<Meeting> meetings = meetingRepository.findAllByCardinalOrderByStartDesc(cardinal);
+
+        // then
+        assertThat(meetings)
+                .hasSize(2)
+                .extracting(Meeting::getTitle)
+                .containsExactly("Meeting 2", "Meeting 1");
+    }
+
+    @Test
+    void findAllByCardinal() {
+        // given
+        int cardinal = 1;
+
+        // when
+        List<Meeting> meetings = meetingRepository.findAllByCardinal(cardinal);
+
+        // then
+        assertThat(meetings)
+                .hasSize(2)
+                .extracting(Meeting::getTitle)
+                .containsExactlyInAnyOrder("Meeting 1", "Meeting 2");
+    }
+
+    @Test
+    void findAllByMeetingStatusAndEndBeforeOrderByEndAsc() {
+        // given
+        MeetingStatus status = MeetingStatus.OPEN;
+
+        // when
+        List<Meeting> meetings = meetingRepository.findAllByMeetingStatusAndEndBeforeOrderByEndAsc(status, LocalDateTime.now().plusDays(5));
+
+        // then
+        assertThat(meetings)
+                .hasSize(2)
+                .extracting(Meeting::getTitle)
+                .containsExactly("Meeting 1", "Meeting 2");
+
+        assertThat(meetings)
+                .extracting(Meeting::getMeetingStatus)
+                .containsOnly(MeetingStatus.OPEN)
+                .doesNotContain(MeetingStatus.CLOSE);
+    }
+
+    @Test
+    void findAllByOrderByStartDesc() {
+        // when
+        List<Meeting> meetings = meetingRepository.findAllByOrderByStartDesc();
+
+        // then
+        assertThat(meetings)
+                .hasSize(3)
+                .extracting(Meeting::getTitle)
+                .containsExactly("Meeting 3", "Meeting 2", "Meeting 1");
+    }
+}

--- a/src/test/java/leets/weeth/domain/schedule/domain/service/EventGetServiceTest.java
+++ b/src/test/java/leets/weeth/domain/schedule/domain/service/EventGetServiceTest.java
@@ -1,0 +1,67 @@
+package leets.weeth.domain.schedule.domain.service;
+
+import leets.weeth.domain.schedule.application.exception.EventNotFoundException;
+import leets.weeth.domain.schedule.application.mapper.ScheduleMapper;
+import leets.weeth.domain.schedule.domain.entity.Event;
+import leets.weeth.domain.schedule.domain.repository.EventRepository;
+import leets.weeth.domain.schedule.test.fixture.ScheduleTestFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class EventGetServiceTest {
+
+    @Mock
+    private EventRepository eventRepository;
+
+    @Mock
+    private ScheduleMapper scheduleMapper;
+
+    @InjectMocks
+    private EventGetService eventGetService;
+
+    private Event testEvent;
+
+    @BeforeEach
+    void setUp() {
+        testEvent = ScheduleTestFixture.createEvent();
+    }
+
+    @Test
+    void testFind() {
+        // given
+        when(eventRepository.findById(1L))
+                .thenReturn(Optional.of(testEvent));
+
+        // when
+        Event event = eventGetService.find(1L);
+
+        // then
+        assertThat(event).isEqualTo(testEvent);
+        verify(eventRepository).findById(1L);
+    }
+
+    @Test
+    void testFindNotFound() {
+        // given
+        Long id = 999L;
+        when(eventRepository.findById(id)).thenReturn(Optional.empty());
+
+        // when & then
+        // 이벤트가 존재하지 않을 때 예외가 발생하는지 확인
+        assertThatThrownBy(() -> eventGetService.find(id))
+                .isInstanceOf(EventNotFoundException.class);
+        verify(eventRepository).findById(id);
+    }
+}

--- a/src/test/java/leets/weeth/domain/schedule/domain/service/MeetingGetServiceTest.java
+++ b/src/test/java/leets/weeth/domain/schedule/domain/service/MeetingGetServiceTest.java
@@ -1,0 +1,71 @@
+package leets.weeth.domain.schedule.domain.service;
+
+import leets.weeth.domain.schedule.application.exception.MeetingNotFoundException;
+import leets.weeth.domain.schedule.application.mapper.ScheduleMapper;
+import leets.weeth.domain.schedule.domain.entity.Meeting;
+import leets.weeth.domain.schedule.domain.repository.MeetingRepository;
+import leets.weeth.domain.schedule.test.fixture.ScheduleTestFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MeetingGetServiceTest {
+
+    @Mock
+    private MeetingRepository meetingRepository;
+
+    @Mock
+    private ScheduleMapper scheduleMapper;
+
+    @InjectMocks
+    private MeetingGetService meetingGetService;
+
+    private Meeting testMeeting;
+
+    @BeforeEach
+    void setUp() {
+        testMeeting = ScheduleTestFixture.createMeeting();
+    }
+
+    @Test
+    @DisplayName("[MeetingGetService] 기본 조회 메서드 테스트")
+    void testFind() {
+        // given
+        when(meetingRepository.findById(1L))
+                .thenReturn(Optional.of(testMeeting));
+
+
+        // when
+        Meeting meeting = meetingGetService.find(1L);
+
+
+        // when
+        assertThat(meeting).isEqualTo(testMeeting);
+        verify(meetingRepository).findById(1L);
+    }
+
+    @Test
+    @DisplayName("[MeetingGetService] null인 경우 예외 발생 테스트")
+    void testFindNotFound() {
+        // given
+        when(meetingRepository.findById(1L))
+                .thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> meetingGetService.find(1L))
+            .isInstanceOf(MeetingNotFoundException.class);
+        verify(meetingRepository).findById(1L);
+    }
+}

--- a/src/test/java/leets/weeth/domain/schedule/test/fixture/ScheduleTestFixture.java
+++ b/src/test/java/leets/weeth/domain/schedule/test/fixture/ScheduleTestFixture.java
@@ -1,0 +1,30 @@
+package leets.weeth.domain.schedule.test.fixture;
+
+import leets.weeth.domain.schedule.domain.entity.Event;
+import leets.weeth.domain.schedule.domain.entity.Meeting;
+
+import java.time.LocalDateTime;
+
+public class ScheduleTestFixture {
+
+    public static Event createEvent() {
+        return Event.builder()
+                .title("Test Meeting")
+                .location("Test Location")
+                .start(LocalDateTime.now())
+                .end(LocalDateTime.now().plusDays(2))
+                .cardinal(1)
+                .build();
+    }
+
+    public static Meeting createMeeting() {
+        return Meeting.builder()
+                .title("Test Meeting")
+                .location("Test Location")
+                .start(LocalDateTime.now())
+                .end(LocalDateTime.now().plusDays(2))
+                .code(1234)
+                .cardinal(1)
+                .build();
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,11 @@
+spring:
+  profiles:
+    active: test
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+        dialect: org.hibernate.dialect.MySQL8Dialect


### PR DESCRIPTION
# 📌 PR 내용
- 캘린더 도메인 중 repository, service layer에 대한 테스트 코드를 작성했습니다.


<br>

## 🔍 PR 세부사항
- @DataJpaTest의 경우 TestContainers 라이브러리를 활용해 테스트 전용 Mysql 컨테이너와 직접 통신해 실제 환경과 유사하게 테스트가 가능하게 했습니다
- 라이브러리, 프레임워크에서 제공하는 기능의 경우는 검증의 영역에서 제외했고, 코드 레벨에서 검증이 가능한 영역 위주로 테스트를 작성했습니다.
- 해당 도메인에서 공통으로 사용될 테스트 데이터들은 중복을 제거하기 위해 fixture로 미리 정의해서 static import 해와서 사용하도록 했습니다.

<br>

## 📸 관련 스크린샷

<br>

## 📝 주의사항
- 라이브러리 버전이 spring 버전과 약간 안 맞을 수 있는데, 후에 스프링 버전을 올리도록 하겠습니다.

<br>

## ✅ 체크리스트

- [x] 리뷰어 설정
- [x] Assignee 설정
- [x] Label 설정
- [x] 제목 양식 맞췄나요? (ex. [WTH-01] PR 템플릿 수정)
- [x] 변경 사항에 대한 테스트


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

이번 업데이트는 내부 테스트 인프라 개선에 중점을 두었으며, 최종 사용자에게 직접적인 변화는 없습니다.

* **Tests**
  * 테스트 환경 안정화를 위한 테스트 인프라 강화
  * 데이터베이스 기반 저장소 및 서비스 테스트 추가

* **Chores**
  * 테스트 의존성 및 빌드 구성 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->