### PR TITLE
[WTH-55] weeth 유저 테스트 코드 마무리

### DIFF
--- a/src/test/java/leets/weeth/domain/user/domain/repository/UserRepositoryTest.java
+++ b/src/test/java/leets/weeth/domain/user/domain/repository/UserRepositoryTest.java
@@ -76,7 +76,7 @@ public class UserRepositoryTest {
 
 	@Test
 	@DisplayName("finAllByStatusOrderByCardinalAndName() : 상태별로 최신 기수순 + 이름 오름차순으로 정렬된다")
-	void finAllByStatusOrderByCardinalAndName() {
+	void findAllByStatusOrderByCardinalAndName() {
 		//given
 		Pageable pageable = PageRequest.of(0,10);
 

--- a/src/test/java/leets/weeth/domain/user/domain/repository/UserRepositoryTest.java
+++ b/src/test/java/leets/weeth/domain/user/domain/repository/UserRepositoryTest.java
@@ -75,7 +75,7 @@ public class UserRepositoryTest {
 	}
 
 	@Test
-	@DisplayName("finAllByStatusOrderByCardinalAndName() : 상태별로 최신 기수순 + 이름 오름차순으로 정렬된다")
+	@DisplayName("findAllByStatusOrderByCardinalAndName() : 상태별로 최신 기수순 + 이름 오름차순으로 정렬된다")
 	void findAllByStatusOrderByCardinalAndName() {
 		//given
 		Pageable pageable = PageRequest.of(0,10);

--- a/src/test/java/leets/weeth/domain/user/domain/repository/UserRepositoryTest.java
+++ b/src/test/java/leets/weeth/domain/user/domain/repository/UserRepositoryTest.java
@@ -75,7 +75,7 @@ public class UserRepositoryTest {
 	}
 
 	@Test
-	@DisplayName("finALlByStatusOrderByCardinalAndName() : 상태별로 최신 기수순 + 이름 오름차순으로 정렬된다")
+	@DisplayName("finAllByStatusOrderByCardinalAndName() : 상태별로 최신 기수순 + 이름 오름차순으로 정렬된다")
 	void finAllByStatusOrderByCardinalAndName() {
 		//given
 		Pageable pageable = PageRequest.of(0,10);
@@ -89,6 +89,23 @@ public class UserRepositoryTest {
 			.hasSize(2)
 			.extracting(User::getName)
 			.containsExactly("적순2", "적순");
+	}
+
+	@Test
+	@DisplayName("findAllByCardinalOrderByNameAsc() : Active인 유저들 중 특정 기수 + 이름 오름차순으로 정렬한다.")
+	void findAllByCardinalOrderByNameAsc() {
+		//given
+		Pageable pageable = PageRequest.of(0,10);
+
+		//when
+		Slice<User> resultSlice = userRepository.findAllByCardinalOrderByNameAsc(Status.ACTIVE, cardinal7,pageable);
+		List<User> result = resultSlice.getContent();
+
+		//then
+		assertThat(result)
+			.hasSize(1)
+			.extracting(User::getName)
+			.containsExactly("적순");
 	}
 
 }

--- a/src/test/java/leets/weeth/domain/user/domain/repository/UserRepositoryTest.java
+++ b/src/test/java/leets/weeth/domain/user/domain/repository/UserRepositoryTest.java
@@ -11,6 +11,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 
 import leets.weeth.config.TestContainersConfig;
 import leets.weeth.domain.user.domain.entity.Cardinal;
@@ -70,4 +73,22 @@ public class UserRepositoryTest {
 			.extracting(User::getName)
 			.containsExactly("적순");
 	}
+
+	@Test
+	@DisplayName("finALlByStatusOrderByCardinalAndName() : 상태별로 최신 기수순 + 이름 오름차순으로 정렬된다")
+	void finAllByStatusOrderByCardinalAndName() {
+		//given
+		Pageable pageable = PageRequest.of(0,10);
+
+		//when
+		Slice<User> resultSlice = userRepository.findAllByStatusOrderedByCardinalAndName(Status.ACTIVE, pageable);
+		List<User> result = resultSlice.getContent();
+
+		//then
+		assertThat(result)
+			.hasSize(2)
+			.extracting(User::getName)
+			.containsExactly("적순2", "적순");
+	}
+
 }

--- a/src/test/java/leets/weeth/domain/user/domain/service/CardinalGetServiceTest.java
+++ b/src/test/java/leets/weeth/domain/user/domain/service/CardinalGetServiceTest.java
@@ -1,0 +1,45 @@
+package leets.weeth.domain.user.domain.service;
+
+import static org.assertj.core.api.AssertionsForClassTypes.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import leets.weeth.domain.user.domain.entity.Cardinal;
+import leets.weeth.domain.user.domain.repository.CardinalRepository;
+
+@ExtendWith(MockitoExtension.class)
+public class CardinalGetServiceTest {
+
+	// validateCardinal() 검증로직 확인
+	@Mock
+	private CardinalRepository cardinalRepository;
+
+	@InjectMocks
+	private CardinalGetService cardinalGetService;
+
+	@Test
+	@DisplayName("findByAdminSide() : 존재하지 않는 기수를 넣었을 때 새로 저장되는지 확인")
+	void findByAdminSide() {
+		//given
+		given(cardinalRepository.findByCardinalNumber(7))
+			.willReturn(Optional.empty());
+
+		given(cardinalRepository.save(any(Cardinal.class))).
+			willReturn(Cardinal.builder().cardinalNumber(7).build());
+
+		//when
+		Cardinal result = cardinalGetService.findByAdminSide(7);
+
+		//then
+		assertThat(result.getCardinalNumber()).isEqualTo(7);
+	}
+
+}

--- a/src/test/java/leets/weeth/domain/user/domain/service/CardinalGetServiceTest.java
+++ b/src/test/java/leets/weeth/domain/user/domain/service/CardinalGetServiceTest.java
@@ -12,6 +12,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import leets.weeth.domain.user.application.exception.DuplicateCardinalException;
 import leets.weeth.domain.user.domain.entity.Cardinal;
 import leets.weeth.domain.user.domain.repository.CardinalRepository;
 
@@ -40,6 +41,30 @@ public class CardinalGetServiceTest {
 
 		//then
 		assertThat(result.getCardinalNumber()).isEqualTo(7);
+	}
+
+	@Test
+	@DisplayName("validateCardinal() : 중복된 기수 저장을 방지하고 예외를 던지는지 확인")
+	void validateCardinal() {
+		//given
+		given(cardinalRepository.findByCardinalNumber(7))
+			.willReturn(Optional.of(Cardinal.builder().cardinalNumber(7).build()));
+
+		//when&then
+		assertThatThrownBy(() -> cardinalGetService.validateCardinal(7))
+			.isInstanceOf(DuplicateCardinalException.class);
+	}
+
+	@Test
+	@DisplayName("validateCardinal() : 중복되지 않는 기수라면 예외를 던지지않고 잘 저장하는지 확인")
+	void validateCardinal_noException() {
+		//given
+		given(cardinalRepository.findByCardinalNumber(7))
+			.willReturn(Optional.empty());
+
+		//when&then
+		assertThatCode(() -> cardinalGetService.validateCardinal(7))
+			.doesNotThrowAnyException();
 	}
 
 }

--- a/src/test/java/leets/weeth/domain/user/domain/service/UserCardinalGetServiceTest.java
+++ b/src/test/java/leets/weeth/domain/user/domain/service/UserCardinalGetServiceTest.java
@@ -12,6 +12,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import leets.weeth.domain.user.application.exception.CardinalNotFoundException;
 import leets.weeth.domain.user.domain.entity.UserCardinal;
 import leets.weeth.domain.user.domain.repository.UserCardinalRepository;
 import leets.weeth.domain.user.test.fixture.CardinalTestFixture;
@@ -38,11 +39,65 @@ public class UserCardinalGetServiceTest {
 
 		given(userCardinalRepository.findAllByUserOrderByCardinalCardinalNumberDesc(user))
 			.willReturn(List.of(userCardinal));
+
 		//when
 		boolean result = userCardinalGetService.notContains(user, targetCardinal);
 
 		//then
 		assertThat(result).isTrue();
+	}
+
+	@Test
+	@DisplayName("isCurrent() : 현재 유저의 최신 기수보다 최신 기수인지 확인")
+	void isCurrent() {
+		//given
+		var user = UserTestFixture.createActiveUser1();
+		var oldCardinal = CardinalTestFixture.createCardinal(7,2025,2);
+		var newCardinal = CardinalTestFixture.createCardinal(8,2026,1);
+		var userCardinal = new UserCardinal(user, oldCardinal);
+
+		given(userCardinalRepository.findAllByUserOrderByCardinalCardinalNumberDesc(user))
+			.willReturn(List.of(userCardinal));
+
+		//when
+		boolean result = userCardinalGetService.isCurrent(user, newCardinal);
+
+		//then
+		assertThat(result).isTrue();
+	}
+
+	@Test
+	@DisplayName("isCurrent(): 새 기수가 기존 최대보다 작으면 false 반환")
+	void isCurrent_returnsFalse_whenOlderCardinal() {
+		// given
+		var user = UserTestFixture.createActiveUser1();
+		var oldCardinal = CardinalTestFixture.createCardinal(7, 2025, 1);
+		var newCardinal = CardinalTestFixture.createCardinal(6, 2024, 2);
+		var userCardinal = new UserCardinal(user, oldCardinal);
+
+		given(userCardinalRepository.findAllByUserOrderByCardinalCardinalNumberDesc(user))
+			.willReturn(List.of(userCardinal));
+
+		// when
+		boolean result = userCardinalGetService.isCurrent(user, newCardinal);
+
+		// then
+		assertThat(result).isFalse();
+	}
+
+	@Test
+	@DisplayName("isCurrent(): 유저가 어떤 기수도 가지고 있지 않으면 CardinalNotFoundException 발생")
+	void isCurrent_throwsException_whenUserHasNoCardinal() {
+		// given
+		var user = UserTestFixture.createActiveUser1();
+		var newCardinal = CardinalTestFixture.createCardinal(8, 2026, 1);
+
+		given(userCardinalRepository.findAllByUserOrderByCardinalCardinalNumberDesc(user))
+			.willReturn(List.of());
+
+		// when & then
+		assertThatThrownBy(() -> userCardinalGetService.isCurrent(user, newCardinal))
+			.isInstanceOf(CardinalNotFoundException.class);
 	}
 
 }

--- a/src/test/java/leets/weeth/domain/user/domain/service/UserCardinalGetServiceTest.java
+++ b/src/test/java/leets/weeth/domain/user/domain/service/UserCardinalGetServiceTest.java
@@ -1,0 +1,48 @@
+package leets.weeth.domain.user.domain.service;
+
+import static org.assertj.core.api.AssertionsForClassTypes.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import leets.weeth.domain.user.domain.entity.UserCardinal;
+import leets.weeth.domain.user.domain.repository.UserCardinalRepository;
+import leets.weeth.domain.user.test.fixture.CardinalTestFixture;
+import leets.weeth.domain.user.test.fixture.UserTestFixture;
+
+@ExtendWith(MockitoExtension.class)
+public class UserCardinalGetServiceTest {
+
+	@Mock
+	private UserCardinalRepository userCardinalRepository;
+
+	@InjectMocks
+	private UserCardinalGetService userCardinalGetService;
+
+
+	@Test
+	@DisplayName("notContains() : 유저의 기수 목록 중, 특정 기수가 없는지 확인 ")
+	void notContains() {
+		//given
+		var user = UserTestFixture.createActiveUser1();
+		var existingCardinal = CardinalTestFixture.createCardinal(7,2025,2);
+		var targetCardinal = CardinalTestFixture.createCardinal(8,2026,1);
+		var userCardinal = new UserCardinal(user, existingCardinal);
+
+		given(userCardinalRepository.findAllByUserOrderByCardinalCardinalNumberDesc(user))
+			.willReturn(List.of(userCardinal));
+		//when
+		boolean result = userCardinalGetService.notContains(user, targetCardinal);
+
+		//then
+		assertThat(result).isTrue();
+	}
+
+}

--- a/src/test/java/leets/weeth/domain/user/domain/service/UserGetServiceTest.java
+++ b/src/test/java/leets/weeth/domain/user/domain/service/UserGetServiceTest.java
@@ -1,0 +1,38 @@
+package leets.weeth.domain.user.domain.service;
+
+import leets.weeth.domain.user.application.exception.UserNotFoundException;
+import leets.weeth.domain.user.domain.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.annotation.DirtiesContext;
+
+import java.util.Optional;
+import static org.mockito.BDDMockito.given;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@ExtendWith(MockitoExtension.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+class UserGetServiceTest {
+
+	@Mock
+	private UserRepository userRepository;
+
+	@InjectMocks
+	private UserGetService userGetService;
+
+	@Test
+	@DisplayName("find(Long Id) : 존재하지 않는 유저일 때 예외를 던진다")
+	void find_userNotFound_throwsException() {
+		//given
+		Long userId = Long.valueOf(1L);
+		given(userRepository.findById(userId)).willReturn(Optional.empty());
+
+		// when & then
+		assertThrows(UserNotFoundException.class, () -> userGetService.find(userId));
+	}
+
+}

--- a/src/test/java/leets/weeth/domain/user/domain/service/UserGetServiceTest.java
+++ b/src/test/java/leets/weeth/domain/user/domain/service/UserGetServiceTest.java
@@ -35,7 +35,7 @@ class UserGetServiceTest {
 	@DisplayName("find(Long Id) : 존재하지 않는 유저일 때 예외를 던진다")
 	void find_id_userNotFound_throwsException() {
 		//given
-		Long userId = Long.valueOf(1L);
+		Long userId = 1L;
 		given(userRepository.findById(userId)).willReturn(Optional.empty());
 
 		// when & then

--- a/src/test/java/leets/weeth/domain/user/domain/service/UserGetServiceTest.java
+++ b/src/test/java/leets/weeth/domain/user/domain/service/UserGetServiceTest.java
@@ -23,7 +23,6 @@ import static org.mockito.BDDMockito.given;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @ExtendWith(MockitoExtension.class)
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 class UserGetServiceTest {
 
 	@Mock

--- a/src/test/java/leets/weeth/domain/user/domain/service/UserGetServiceTest.java
+++ b/src/test/java/leets/weeth/domain/user/domain/service/UserGetServiceTest.java
@@ -1,6 +1,7 @@
 package leets.weeth.domain.user.domain.service;
 
 import leets.weeth.domain.user.application.exception.UserNotFoundException;
+import leets.weeth.domain.user.domain.entity.User;
 import leets.weeth.domain.user.domain.repository.UserRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -8,9 +9,16 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.data.domain.SliceImpl;
 
+import java.util.List;
 import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -44,6 +52,22 @@ class UserGetServiceTest {
 
 		//when & then
 		assertThrows(UserNotFoundException.class, () -> userGetService.find(email));
+	}
+
+	@Test
+	@DisplayName("findAll(Pageable pageable) : 빈 슬라이스 반환 시 , 유저 예외 던진다")
+	void findAll_userNotFound_throwsException() {
+		//given
+		Pageable pageable = PageRequest.of(0, 10);
+		Slice<User> emptySlice = new SliceImpl<>(List.of(), pageable, false);
+
+		given(userRepository.findAllByStatusOrderedByCardinalAndName(any(), eq(pageable)))
+			.willReturn(emptySlice);
+
+		//when & then
+		assertThrows(UserNotFoundException.class,
+			() -> userGetService.findAll(pageable));
+
 	}
 
 }

--- a/src/test/java/leets/weeth/domain/user/domain/service/UserGetServiceTest.java
+++ b/src/test/java/leets/weeth/domain/user/domain/service/UserGetServiceTest.java
@@ -26,13 +26,24 @@ class UserGetServiceTest {
 
 	@Test
 	@DisplayName("find(Long Id) : 존재하지 않는 유저일 때 예외를 던진다")
-	void find_userNotFound_throwsException() {
+	void find_id_userNotFound_throwsException() {
 		//given
 		Long userId = Long.valueOf(1L);
 		given(userRepository.findById(userId)).willReturn(Optional.empty());
 
 		// when & then
 		assertThrows(UserNotFoundException.class, () -> userGetService.find(userId));
+	}
+
+	@Test
+	@DisplayName("find(String email) : 존재하지 않는 유저일 때 예외를 던진다")
+	void find_email_userNotFound_throwsException() {
+		//given
+		String email = "test@test.com";
+		given(userRepository.findByEmail(email)).willReturn(Optional.empty());
+
+		//when & then
+		assertThrows(UserNotFoundException.class, () -> userGetService.find(email));
 	}
 
 }


### PR DESCRIPTION
# 📌 PR 내용
기존에 진행되면 유저 테스트 코드 미비된 부분을 추가 작성하였습니다.

리포지토리 관련해서 몇몇 빠진 메소드 및 서비스로직 테스트 파일 생성해서 작성하였습니다!
Service 파일에서 Spring Data JPA가 자동으로 생성하고 처리하는 단순 CRUD 메서드는 별도로 테스트에서 제외 하였습니다.
CRUD라도, 예외가 있는 경우 검증 테스트를 포함하였습니다!

Fixture를 사용할 수 있는 경우는 사용하여서 중복을 최대한 제거하였습니다.
<br>

## 🔍 PR 세부사항

<br>

## 📸 관련 스크린샷

<br>

## 📝 주의사항

<br>

## ✅ 체크리스트

- [x] 리뷰어 설정
- [x] Assignee 설정
- [x] Label 설정
- [x] 제목 양식 맞췄나요? (ex. [WTH-01] PR 템플릿 수정)
- [x] 변경 사항에 대한 테스트


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **테스트**
  * 사용자 저장소의 페이징·정렬 조회 시 동작을 검증하는 추가 테스트(활성 사용자 필터링 및 정렬 결과 검증 포함)
  * Cardinal 조회·생성 흐름과 중복 검증 경로를 검증하는 단위 테스트 추가
  * 사용자-카디널 연관 로직의 최신성 판정과 부존재 시 예외 처리를 검증하는 테스트 추가
  * 조회 서비스의 ID/이메일/페이지 조회 실패 시 예외 발생 경로 검증 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->