### PR TITLE
[WTH-59] openjdk -> eclipse-temurin 이미지 교체

### DIFF
--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -1,5 +1,5 @@
-# open jdk 17 버전의 alpine 리눅스 환경을 구성
-FROM openjdk:17-alpine
+# eclipse-temurin 17 버전의 alpine 리눅스 환경을 구성
+FROM eclipse-temurin:17-jdk-alpine
 
 # build가 되는 시점에 JAR_FILE이라는 변수 명에 build/libs/*.jar 선언
 # build/libs - gradle로 빌드했을 때 jar 파일이 생성되는 경로

--- a/Dockerfile-prod
+++ b/Dockerfile-prod
@@ -1,5 +1,5 @@
-# open jdk 17 버전의 alpine 리눅스 환경을 구성
-FROM openjdk:17-alpine
+# eclipse-temurin 17 버전의 alpine 리눅스 환경을 구성
+FROM eclipse-temurin:17-jdk-alpine
 
 # build가 되는 시점에 JAR_FILE이라는 변수 명에 build/libs/*.jar 선언
 # build/libs - gradle로 빌드했을 때 jar 파일이 생성되는 경로

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.3.1'
+	id 'org.springframework.boot' version '3.5.7'
 	id 'io.spring.dependency-management' version '1.1.5'
 }
 


### PR DESCRIPTION
# 📌 PR 내용
- openjdk -> eclipse-temurin 으로 이미지 변경
- Spring Boot 버전 3.3.1 -> 3.5.7 업데이트
<br>

## 🔍 PR 세부사항
- openjdk Docker Hub 이미지 공식 지원 종료로 인한 이미지 교체가 필요
<br>

## 📸 관련 스크린샷
- x
<br>

## 📝 주의사항
- x
<br>

## ✅ 체크리스트

- [ ] 리뷰어 설정
- [ ] Assignee 설정
- [ ] Label 설정
- [ ] 제목 양식 맞췄나요? (ex. [WTH-01] PR 템플릿 수정)
- [ ] 변경 사항에 대한 테스트


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 기본 Java 런타임 이미지가 최신 에디션으로 교체되었습니다.
  * 개발/프로덕션 컨테이너 구성이 빌드 아티팩트 전달과 실행 프로파일 지정 방식으로 정리되었습니다.
  * 빌드 도구의 Spring Boot 플러그인 버전이 상위 버전으로 업데이트되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->