### PR TITLE
[WTH-57] 출석 시간 10분 전 출석 가능하도록 수정

### DIFF
--- a/src/main/java/leets/weeth/domain/attendance/application/usecase/AttendanceUseCaseImpl.java
+++ b/src/main/java/leets/weeth/domain/attendance/application/usecase/AttendanceUseCaseImpl.java
@@ -44,7 +44,7 @@ public class AttendanceUseCaseImpl implements AttendanceUseCase {
 
         LocalDateTime now = LocalDateTime.now();
         Attendance todayMeeting = user.getAttendances().stream()
-                .filter(attendance -> attendance.getMeeting().getStart().isBefore(now)
+                .filter(attendance -> attendance.getMeeting().getStart().minusMinutes(10).isBefore(now)
                         && attendance.getMeeting().getEnd().isAfter(now))
                 .findAny()
                 .orElseThrow(AttendanceNotFoundException::new);

--- a/src/test/java/leets/weeth/domain/attendance/application/usecase/AttendanceUseCaseImplTest.java
+++ b/src/test/java/leets/weeth/domain/attendance/application/usecase/AttendanceUseCaseImplTest.java
@@ -1,20 +1,5 @@
 package leets.weeth.domain.attendance.application.usecase;
 
-import static leets.weeth.domain.attendance.test.fixture.AttendanceTestFixture.*;
-import static org.assertj.core.api.Assertions.*;
-import static org.mockito.BDDMockito.*;
-
-import java.time.LocalDate;
-import java.util.List;
-
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-
 import leets.weeth.domain.attendance.application.dto.AttendanceDTO;
 import leets.weeth.domain.attendance.application.exception.AttendanceCodeMismatchException;
 import leets.weeth.domain.attendance.application.exception.AttendanceNotFoundException;
@@ -30,6 +15,23 @@ import leets.weeth.domain.user.domain.entity.Cardinal;
 import leets.weeth.domain.user.domain.entity.User;
 import leets.weeth.domain.user.domain.service.UserCardinalGetService;
 import leets.weeth.domain.user.domain.service.UserGetService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static leets.weeth.domain.attendance.test.fixture.AttendanceTestFixture.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.BDDMockito.*;
 
 @ExtendWith(MockitoExtension.class)
 public class AttendanceUseCaseImplTest {
@@ -76,6 +78,55 @@ public class AttendanceUseCaseImplTest {
 		then(attendanceMapper).shouldHaveNoMoreInteractions();
 	}
 
+	@Test
+	@DisplayName("10분 전부터 출석이 가능한지 확인")
+	void checkIn_10MinutesBeforeMeeting_ShouldSucceed() {
+		// given
+		LocalDateTime now = LocalDateTime.now();
+		Meeting meeting = Meeting.builder()
+				.start(now.plusMinutes(5))  // 5분 뒤 시작 (checkIn 로직의 '10분 전' 범위 내)
+				.end(now.plusHours(2))
+				.code(1234)
+				.title("Today")
+				.cardinal(1)
+				.build();
+
+		User user = createActiveUserWithAttendances(
+				"이지훈", List.of(meeting)
+		);
+
+		when(userGetService.find(userId)).thenReturn(user);
+
+
+		// when & then
+		assertDoesNotThrow(() -> attendanceUseCase.checkIn(userId, 1234));
+		verify(attendanceUpdateService, times(1)).attend(any(Attendance.class));
+	}
+
+	@Test
+	@DisplayName("11분 전에 출석시 오류 확인")
+	void checkIn_10MinutesBeforeMeeting_ShouldFailed() {
+		// given
+		LocalDateTime now = LocalDateTime.now();
+		Meeting meeting = Meeting.builder()
+				.start(now.plusMinutes(11))  // 5분 뒤 시작 (checkIn 로직의 '10분 전' 범위 내)
+				.end(now.plusHours(2))
+				.code(1234)
+				.title("Today")
+				.cardinal(1)
+				.build();
+
+		User user = createActiveUserWithAttendances(
+				"이지훈", List.of(meeting)
+		);
+
+		when(userGetService.find(userId)).thenReturn(user);
+
+
+		// when & then
+		assertThatThrownBy(() -> attendanceUseCase.checkIn(userId, 1234))
+				.isInstanceOf(AttendanceNotFoundException.class);
+	}
 	@Test
 	@DisplayName("find: '시작/종료 날짜가 모두 오늘'인 출석이 없다면, mapper.toMainDto(user, null)을 호출")
 	void find_noExactToday_returnsNullMapped() {

--- a/src/test/java/leets/weeth/domain/attendance/application/usecase/AttendanceUseCaseImplTest.java
+++ b/src/test/java/leets/weeth/domain/attendance/application/usecase/AttendanceUseCaseImplTest.java
@@ -109,7 +109,7 @@ public class AttendanceUseCaseImplTest {
 		// given
 		LocalDateTime now = LocalDateTime.now();
 		Meeting meeting = Meeting.builder()
-				.start(now.plusMinutes(11))  // 5분 뒤 시작 (checkIn 로직의 '10분 전' 범위 내)
+				.start(now.plusMinutes(11))  // 11분뒤 시작  -> 오류 발생해야함
 				.end(now.plusHours(2))
 				.code(1234)
 				.title("Today")


### PR DESCRIPTION
# 📌 PR 내용
- 프론트에 맞게 백엔드도 10분 전부터 출석이 가능하도록 필터링을 수정했습니다


<br>

## 🔍 PR 세부사항
- AS-IS: 출석 시작 시간 사이에 있는 경우만 출석 객체를 필터링
- TO-BE: 출석 시작 10분 전에도 필터링 되도록 수정
- startTime이 19:00이라면 10분을 땡겨 18:50분부터 필터링이 되도록 설정
- 관련 로직 검증을 위한 테스트 코드 추가

<br>

## 📸 관련 스크린샷

<br>

## 📝 주의사항

<br>

## ✅ 체크리스트

- [x] 리뷰어 설정
- [x] Assignee 설정
- [x] Label 설정
- [x] 제목 양식 맞췄나요? (ex. [WTH-01] PR 템플릿 수정)
- [x] 변경 사항에 대한 테스트


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 회의 체크인 가능 시간이 확대되었습니다. 기존에는 회의 시작 이후만 가능했으나, 이제 회의 시작 10분 전부터 체크인할 수 있어 참석 준비가 더 유연해졌습니다.

* **테스트**
  * 확대된 체크인 시간 범위를 검증하는 새로운 테스트 케이스들이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->