### PR TITLE
[WTH-63] fix : em.flush() 와 clear()을 사용하여 메모리와 DB 상태 통일

### DIFF
--- a/src/main/java/leets/weeth/domain/schedule/application/usecase/MeetingUseCaseImpl.java
+++ b/src/main/java/leets/weeth/domain/schedule/application/usecase/MeetingUseCaseImpl.java
@@ -47,7 +47,7 @@ public class MeetingUseCaseImpl implements MeetingUseCase {
     private final CardinalGetService cardinalGetService;
 
     @PersistenceContext
-    private final EntityManager em;
+    private EntityManager em;
 
     @Override
     public Response find(Long userId, Long meetingId) {

--- a/src/main/java/leets/weeth/domain/schedule/application/usecase/MeetingUseCaseImpl.java
+++ b/src/main/java/leets/weeth/domain/schedule/application/usecase/MeetingUseCaseImpl.java
@@ -1,5 +1,7 @@
 package leets.weeth.domain.schedule.application.usecase;
 
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 import leets.weeth.domain.attendance.domain.entity.Attendance;
 import leets.weeth.domain.attendance.domain.service.AttendanceDeleteService;
 import leets.weeth.domain.attendance.domain.service.AttendanceGetService;
@@ -43,6 +45,9 @@ public class MeetingUseCaseImpl implements MeetingUseCase {
     private final AttendanceDeleteService attendanceDeleteService;
     private final AttendanceUpdateService attendanceUpdateService;
     private final CardinalGetService cardinalGetService;
+
+    @PersistenceContext
+    private final EntityManager em;
 
     @Override
     public Response find(Long userId, Long meetingId) {
@@ -102,6 +107,10 @@ public class MeetingUseCaseImpl implements MeetingUseCase {
         List<Attendance> attendances = attendanceGetService.findAllByMeeting(meeting);
 
         attendanceUpdateService.updateUserAttendanceByStatus(attendances);
+
+        em.flush();
+        em.clear();
+
 
         attendanceDeleteService.deleteAll(meeting);
         meetingDeleteService.delete(meeting);

--- a/src/main/java/leets/weeth/domain/schedule/application/usecase/MeetingUseCaseImpl.java
+++ b/src/main/java/leets/weeth/domain/schedule/application/usecase/MeetingUseCaseImpl.java
@@ -111,7 +111,6 @@ public class MeetingUseCaseImpl implements MeetingUseCase {
         em.flush();
         em.clear();
 
-
         attendanceDeleteService.deleteAll(meeting);
         meetingDeleteService.delete(meeting);
     }


### PR DESCRIPTION
# 📌 PR 내용

Event Admin api로  Meeting을 생성 한 후, 
Meeting Admin api로 Meeting을 delete 할 시 나타나는
transientObjectException: persistent instance references an unsaved transient instance of '...Meeting' 과 관련하여

InvalidDataAccessApiUsageException 에러 발생을 해결해보았습니다.
<br>

## 🔍 PR 세부사항

AttendanceRepository에서 삭제로직에 사용되는 벌크 JPQL은 DB만 바꾸고, 1차 캐시는 안 건드린다. 가 DB와 메모리의 불일치를 야기했습니다.

이에 따라 엔티티매니저를 생성해서, 메모리와 DB를 동기화하고  메모리를 비웠습니다

<br>

## 📸 관련 스크린샷

<br>

## 📝 주의사항

<br>

## ✅ 체크리스트

- [ ] 리뷰어 설정
- [ ] Assignee 설정
- [ ] Label 설정
- [ ] 제목 양식 맞췄나요? (ex. [WTH-01] PR 템플릿 수정)
- [ ] 변경 사항에 대한 테스트


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 모임 삭제 처리의 내부 트랜잭션 정리 및 데이터 플러시/캐시 정리를 추가하여 참석자 정보 제거가 일관되게 반영되도록 개선했습니다.

---

**주의:** 사용자에게 보이는 새로운 기능이나 공개 API 변경은 없습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->