### PR TITLE
[WTH-65] @Query 기반 JPQL을 QueryDSL로 리팩토링

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,12 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 	implementation 'com.auth0:java-jwt:4.2.1'
 
+	// QueryDSL
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
+	annotationProcessor 'jakarta.persistence:jakarta.persistence-api:3.1.0'
+	annotationProcessor 'jakarta.annotation:jakarta.annotation-api:2.1.1'
+
 	// mapStruct
 	implementation 'org.mapstruct:mapstruct:1.5.3.Final'
 	annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.3.Final'

--- a/src/main/java/leets/weeth/domain/board/domain/repository/PostRepository.java
+++ b/src/main/java/leets/weeth/domain/board/domain/repository/PostRepository.java
@@ -12,7 +12,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 
-public interface PostRepository extends JpaRepository<Post, Long> {
+public interface PostRepository extends JpaRepository<Post, Long>, PostRepositoryCustom {
 
 	@Query("""
         SELECT p FROM Post p

--- a/src/main/java/leets/weeth/domain/board/domain/repository/PostRepositoryCustom.java
+++ b/src/main/java/leets/weeth/domain/board/domain/repository/PostRepositoryCustom.java
@@ -1,0 +1,14 @@
+package leets.weeth.domain.board.domain.repository;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+
+import leets.weeth.domain.board.domain.entity.Post;
+
+public interface PostRepositoryCustom {
+
+	Slice<Post> findRecentPart(Pageable pageable);
+
+	Slice<Post> searchPart(String kw,Pageable pageable);
+
+}

--- a/src/main/java/leets/weeth/domain/board/domain/repository/PostRepositoryCustom.java
+++ b/src/main/java/leets/weeth/domain/board/domain/repository/PostRepositoryCustom.java
@@ -1,14 +1,26 @@
 package leets.weeth.domain.board.domain.repository;
 
+import java.util.Collection;
+import java.util.List;
+
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
+import org.springframework.data.repository.query.Param;
 
 import leets.weeth.domain.board.domain.entity.Post;
+import leets.weeth.domain.board.domain.entity.enums.Category;
+import leets.weeth.domain.board.domain.entity.enums.Part;
 
 public interface PostRepositoryCustom {
 
 	Slice<Post> findRecentPart(Pageable pageable);
-
+	Slice<Post> findRecentEducation(Pageable pageable);
 	Slice<Post> searchPart(String kw,Pageable pageable);
+	Slice<Post> searchEducation(String kw, Pageable pageable);
+	List<String> findDistinctStudyNamesByPart(Part part);
+	Slice<Post> findByPartAndOptionalFilters(Part part, Category category, Integer cardinal, String studyName, Integer week, Pageable pageable);
+	Slice<Post> findByCategoryAndOptionalCardinalWithPart(String partName, Category category, Integer cardinal, Pageable pageable);
+	Slice<Post> findByCategoryAndCardinalNumberWithPart(String partName, Category category, Integer cardinal, Pageable pageable);
+	Slice<Post> findByCategoryAndCardinalInWithPart(String partName, Category category,  Collection<Integer> cardinals, Pageable pageable);
 
 }

--- a/src/main/java/leets/weeth/domain/board/domain/repository/PostRepositoryImpl.java
+++ b/src/main/java/leets/weeth/domain/board/domain/repository/PostRepositoryImpl.java
@@ -9,17 +9,21 @@ import org.springframework.stereotype.Repository;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
+import jakarta.persistence.EntityManager;
 import leets.weeth.domain.board.domain.entity.Post;
 import leets.weeth.domain.board.domain.entity.QPost;
 import leets.weeth.domain.board.domain.entity.enums.Category;
 import lombok.RequiredArgsConstructor;
 
-@Repository
-@RequiredArgsConstructor
+
 public class PostRepositoryImpl implements PostRepositoryCustom {
 
 	private final JPAQueryFactory queryFactory;
 	private final QPost post = QPost.post;
+
+	public PostRepositoryImpl(EntityManager em) {
+		this.queryFactory = new JPAQueryFactory(em);
+	}
 
 	@Override
 	public Slice<Post> findRecentPart(Pageable pageable) {

--- a/src/main/java/leets/weeth/domain/board/domain/repository/PostRepositoryImpl.java
+++ b/src/main/java/leets/weeth/domain/board/domain/repository/PostRepositoryImpl.java
@@ -1,18 +1,26 @@
 package leets.weeth.domain.board.domain.repository;
 
+import java.beans.Expression;
+import java.util.Collection;
 import java.util.List;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
+import org.springframework.data.repository.query.Param;
+import org.springframework.security.core.parameters.P;
 import org.springframework.stereotype.Repository;
 
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import jakarta.persistence.EntityManager;
 import leets.weeth.domain.board.domain.entity.Post;
 import leets.weeth.domain.board.domain.entity.QPost;
 import leets.weeth.domain.board.domain.entity.enums.Category;
+import leets.weeth.domain.board.domain.entity.enums.Part;
 import lombok.RequiredArgsConstructor;
 
 
@@ -65,4 +73,207 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
 
 		return new SliceImpl<>(result, pageable, hasNext);
  	}
+
+	 @Override
+	 public Slice<Post> findRecentEducation(Pageable pageable) {
+		List<Post> result = queryFactory
+			.selectFrom(post)
+			.where(post.category.eq(Category.Education))
+			.orderBy(post.id.desc())
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize() + 1)
+			.fetch();
+
+		boolean hasNext = result.size() > pageable.getPageSize();
+
+		if (hasNext) {
+			result.remove(pageable.getPageSize());
+		}
+
+		return new SliceImpl<>(result, pageable, hasNext);
+	 }
+
+	 @Override
+	public Slice<Post> searchEducation(String kw, Pageable pageable) {
+		List<Post> result = queryFactory
+			.selectFrom(post)
+			.where(
+				post.category.eq(Category.Education)
+					.and(
+						post.title.containsIgnoreCase(kw)
+							.or(post.content.containsIgnoreCase(kw))
+					)
+			)
+			.orderBy(post.id.desc())
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize() + 1)
+			.fetch();
+
+		 boolean hasNext = result.size() > pageable.getPageSize();
+
+		 if (hasNext) {
+			 result.remove(pageable.getPageSize());
+		 }
+
+		 return new SliceImpl<>(result, pageable, hasNext);
+	 }
+
+	 @Override
+	public List<String> findDistinctStudyNamesByPart(Part part) {
+
+		 return queryFactory
+			 .select(post.studyName)
+			 .distinct()
+			 .from(post)
+			 .where(
+				 part == Part.ALL
+					 ? post.studyName.isNotNull()
+					 : post.part.eq(part).and(post.studyName.isNotNull())
+			 )
+			 .orderBy(post.studyName.asc())
+			 .fetch();
+	}
+
+	@Override //조건이 많은 쿼리라 BooleanBuilder 사용
+	public Slice<Post> findByPartAndOptionalFilters(Part part, Category category, Integer cardinal, String studyName, Integer week, Pageable pageable) {
+
+		BooleanBuilder builder = new BooleanBuilder();
+
+		if (part == Part.ALL) {
+			builder.and(post.part.eq(Part.ALL).or(post.part.ne(Part.ALL)));
+		}else {
+			builder.and(post.part.eq(part).or(post.part.eq(Part.ALL)));
+		}
+
+		if (category != null) {
+			builder.and(post.category.eq(category));
+		}
+
+		if (cardinal != null) {
+			builder.and(post.cardinalNumber.eq(cardinal));
+		}
+
+		if (studyName != null) {
+			builder.and(post.studyName.eq(studyName));
+		}
+
+		if (week != null) {
+			builder.and(post.week.eq(week));
+		}
+
+		List<Post> result = queryFactory
+			.selectFrom(post)
+			.where(builder)
+			.orderBy(post.id.desc())
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize() + 1)
+			.fetch();
+
+		boolean hasNext = result.size() > pageable.getPageSize();
+
+		if (hasNext) {
+			result.remove(pageable.getPageSize());
+		}
+		return new SliceImpl<>(result, pageable, hasNext);
+
+	}
+
+	@Override
+	public Slice<Post> findByCategoryAndOptionalCardinalWithPart(String partName, Category category, Integer cardinal, Pageable pageable) {
+
+		BooleanBuilder builder = new BooleanBuilder();
+
+		builder.and(post.category.eq(category));
+
+		if (cardinal != null) {
+			builder.and(post.cardinalNumber.eq(cardinal));
+		}
+
+		if (!"ALL".equals(partName)) { //partName 조건
+			builder.and(
+				Expressions.numberTemplate(Integer.class,
+						"FIND_IN_SET({0}, {1})", partName, post.parts).gt(0)
+					.or(Expressions.numberTemplate(Integer.class,
+						"FIND_IN_SET('ALL', {0})", post.parts).gt(0))
+			);
+		}
+
+		List<Post> result = queryFactory
+			.selectFrom(post)
+			.where(builder)
+			.orderBy(post.id.desc())
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize() + 1)
+			.fetch();
+		boolean hasNext = result.size() > pageable.getPageSize();
+		if (hasNext) result.remove(pageable.getPageSize());
+
+		return new SliceImpl<>(result, pageable, hasNext);
+	}
+
+	@Override
+	public Slice<Post> findByCategoryAndCardinalNumberWithPart(String partName, Category category, Integer cardinal, Pageable pageable) {
+
+		BooleanBuilder builder = new BooleanBuilder();
+
+		builder.and(post.category.eq(category));
+		builder.and(post.cardinalNumber.eq(cardinal));
+
+		if (!"ALL".equals(partName)) {
+			BooleanExpression containsPart =
+				Expressions.numberTemplate(Integer.class, "FIND_IN_SET({0}, {1})", partName, post.parts).gt(0);
+
+			BooleanExpression containsAll =
+				Expressions.numberTemplate(Integer.class,
+					"FIND_IN_SET('ALL', {0})", post.parts).gt(0);
+
+			builder.and(containsPart.or(containsAll));
+		}
+
+		List<Post> result = queryFactory
+			.selectFrom(post)
+			.where(builder)
+			.orderBy(post.id.desc())
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize() + 1)
+			.fetch();
+
+		boolean hasNext = result.size() > pageable.getPageSize();
+		if (hasNext) result.remove(pageable.getPageSize());
+
+		return new SliceImpl<>(result, pageable, hasNext);
+	}
+
+	@Override
+	public Slice<Post> findByCategoryAndCardinalInWithPart(String partName, Category category,  Collection<Integer> cardinals, Pageable pageable) {
+		BooleanBuilder builder = new BooleanBuilder();
+
+		builder.and(post.category.eq(category));
+		builder.and(post.cardinalNumber.in(cardinals));
+
+		if (!"ALL".equals(partName)) {
+			BooleanExpression containsPart =
+				Expressions.numberTemplate(Integer.class,
+					"FIND_IN_SET({0}, {1})", partName, post.parts).gt(0);
+
+			BooleanExpression containsAll =
+				Expressions.numberTemplate(Integer.class,
+					"FIND_IN_SET('ALL', {0})", post.parts).gt(0);
+
+			builder.and(containsPart.or(containsAll));
+		}
+
+		List<Post> result = queryFactory
+			.selectFrom(post)
+			.where(builder)
+			.orderBy(post.id.desc())
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize() + 1)
+			.fetch();
+
+		boolean hasNext = result.size() > pageable.getPageSize();
+		if (hasNext) result.remove(pageable.getPageSize());
+
+		return new SliceImpl<>(result, pageable, hasNext);
+	}
 }

--- a/src/main/java/leets/weeth/domain/board/domain/repository/PostRepositoryImpl.java
+++ b/src/main/java/leets/weeth/domain/board/domain/repository/PostRepositoryImpl.java
@@ -1,0 +1,64 @@
+package leets.weeth.domain.board.domain.repository;
+
+import java.util.List;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import leets.weeth.domain.board.domain.entity.Post;
+import leets.weeth.domain.board.domain.entity.QPost;
+import leets.weeth.domain.board.domain.entity.enums.Category;
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class PostRepositoryImpl implements PostRepositoryCustom {
+
+	private final JPAQueryFactory queryFactory;
+	private final QPost post = QPost.post;
+
+	@Override
+	public Slice<Post> findRecentPart(Pageable pageable) {
+		List<Post> result = queryFactory
+			.selectFrom(post)
+			.where(post.category.in(Category.StudyLog, Category.Article))
+			.orderBy(post.id.desc())
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize() + 1)
+			.fetch();
+
+		boolean hasNext = result.size() > pageable.getPageSize();
+
+		if (hasNext) {
+			result.remove(pageable.getPageSize());
+		}
+
+		return new SliceImpl<>(result, pageable, hasNext);
+	}
+
+	@Override
+	public Slice<Post> searchPart(String kw, Pageable pageable) {
+		List<Post> result = queryFactory
+			.selectFrom(post)
+			.where(post.category.in(Category.StudyLog, Category.Article)
+				.and(post.title.containsIgnoreCase(kw)
+					.or(post.content.containsIgnoreCase(kw))
+			))
+			.orderBy(post.id.desc())
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize() + 1)
+			.fetch();
+
+		boolean hasNext = result.size() > pageable.getPageSize();
+
+		if (hasNext) {
+			result.remove(pageable.getPageSize());
+		}
+
+		return new SliceImpl<>(result, pageable, hasNext);
+ 	}
+}

--- a/src/main/java/leets/weeth/global/config/QuerydslConfig.java
+++ b/src/main/java/leets/weeth/global/config/QuerydslConfig.java
@@ -1,0 +1,17 @@
+package leets.weeth.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import jakarta.persistence.EntityManager;
+
+@Configuration
+public class QuerydslConfig {
+
+	@Bean
+	public JPAQueryFactory jpaQueryFactory(EntityManager em) {
+		return new JPAQueryFactory(em);
+	}
+}

--- a/src/test/java/leets/weeth/domain/board/domain/repository/PostRepositoryTest.java
+++ b/src/test/java/leets/weeth/domain/board/domain/repository/PostRepositoryTest.java
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;

--- a/src/test/java/leets/weeth/domain/board/domain/repository/PostRepositoryTest.java
+++ b/src/test/java/leets/weeth/domain/board/domain/repository/PostRepositoryTest.java
@@ -1,0 +1,86 @@
+package leets.weeth.domain.board.domain.repository;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import leets.weeth.config.TestContainersConfig;
+import leets.weeth.domain.board.domain.entity.Post;
+import leets.weeth.domain.board.domain.entity.enums.Category;
+import leets.weeth.domain.board.domain.entity.enums.Part;
+import leets.weeth.global.config.QuerydslConfig;
+
+@DataJpaTest
+@Import({TestContainersConfig.class , QuerydslConfig.class})
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+public class PostRepositoryTest {
+
+	@Autowired
+	private PostRepository postRepository;
+
+	@BeforeEach
+	void setUp() {
+		Post post1 = Post.builder()
+			.title("dsl 테스트 제목")
+			.content("QueryDSL동작확인")
+			.category(Category.StudyLog)
+			.cardinalNumber(1)
+			.week(1)
+			.parts(List.of(Part.BE))
+			.build();
+
+		Post post2 = Post.builder()
+			.title("테스트 제목2")
+			.content("2동작2확인2")
+			.category(Category.Article)
+			.cardinalNumber(2)
+			.week(1)
+			.parts(List.of(Part.BE))
+			.build();
+
+		postRepository.saveAll(List.of(post1,post2));
+
+	}
+
+
+	@Test
+	@DisplayName("findRecentPart(): StudyLog 또는 Article 카테고리 게시글 최신순 조회")
+	void findRecentPart_success() {
+		//given
+		Pageable pageable = PageRequest.of(0, 10);
+
+		//when
+		var result = postRepository.findRecentPart(pageable);
+
+		//then
+		assertThat(result).isNotNull();
+		assertThat(result.getContent()).hasSize(2);
+		assertThat(result.getContent().get(0).getTitle()).isEqualTo("테스트 제목2");
+	}
+
+	@Test
+	@DisplayName("searchPart(): 키워드 기반 검색")
+	void searchPart_success() {
+		//given
+		Pageable pageable = PageRequest.of(0, 10);
+
+		//when
+		var result = postRepository.searchPart("dsl", pageable);
+
+		//then
+		assertThat(result.getContent()).hasSize(1);
+		assertThat(result.getContent().get(0).getTitle()).isEqualTo("dsl 테스트 제목");
+	}
+}
+


### PR DESCRIPTION
# 📌 PR 내용
기존 PostRepository의 메소드는 다수의 쿼리를 @Query 어노테이션 기반 JPQL로 작성하고 있었습니다.
+ 쿼리 동작 시간 확인( 주의사항 탭에서 설명)

### 예시
<img width="782" height="676" alt="스크린샷 2025-11-11 오후 10 36 03" src="https://github.com/user-attachments/assets/8f9af48b-1b03-415c-8bce-74b73c7dea4a" />

이러한 코드작성은 다음과 같은 한계가 존재합니다.


1. 컴파일 시점에 타입 검증 불가 ( 런타임에 발생)
2. 가독성 저하 (너무 김)
3. 동적 조건 작성이 어려움 (where절 등..)

이에 따라 QueryDSL 기반으로 전환하여 ,
타입 안전성, 가독성, 동적 쿼리 확장성을 개선해보았습니다.

흐름은 다음과 같습니다.
1. Q클래스 생성 (컴파일 시점에 엔티티 기반 Q클래스 자동 생성)
2. JPAQueryFactory를 통해 DSL 코드 작성 
3. JPQL 빌드 후 Hibernate에서 쿼리로 변환
4. DB실행

### 변경사항 
PostRepository 내 @Query 직접 작성 -> PostRepositoryCustom + PostRepositoryImpl 분리
수정한 2개의 메소드 테스트 코드 작성 (로그 확인)

### 변경효과
*JPQL 문자열 없이 메서드 체인 방식으로 limit, offset, orderBy 등을 설정할 수 있습니다.
*Slice 기반의 페이징 로직(hasNext, offset, limit)을 직접 제어할 수 있습니다.
*Q클래스를 통해 엔티티 필드 변경 시점에서 IDE가 즉시 오류를 감지합니다.
*BooleanBuilder, where절 재사용으로 중복 쿼리 로직을 제거할 수 있습니다.


<br>

## 🔍 PR 세부사항
솔직히 처음 쿼리 최적화의 목적은 JPQL의 너무 길고 중복되는 로직을 줄이고자 였습니다.
허나 QueryDSL도 만만치 않게 복잡함을 알게되었고 우선 2개의 메소드만 반영해 PR로 작성하였습니다.
위 방식에 대한 다른 분들의 의견이 궁금합니다. (적용하는게 맞을지!)
이 방식이 수용되면 차차 확장적으로 코드를 리팩토링해 나가겠습니다!


<br>

## 📸 관련 스크린샷

<img width="798" height="508" alt="스크린샷 2025-11-11 오후 10 11 40" src="https://github.com/user-attachments/assets/dd32ef6b-ea52-4388-8fa2-cf1785677985" />

로그가 길어서 다 담지는 못하였지만, 
기존에 메소드 (@Query 기반 JPQL)는 아래와 같은 로그
`select p from Post p where p.category in (leets.weeth.domain.board.domain.entity.enums.Category.StudyLog, ...)
`
-> → 이런 식으로 엔티티 경로 + enum 풀 경로가 다 찍힘

QueryDSL 로그 예시
`Hibernate: select p1_0.id,p1_0.cardinal_number,p1_0.category,p1_0.comment_count,p1_0.content,p1_0.created_at,p1_0.modified_at,p1_0.part,p1_0.parts,p1_0.study_name,p1_0.title,p1_0.user_id,p1_0.week from post p1_0 where p1_0.category in ('StudyLog','Article') and (lower(p1_0.title) like lower(concat('%',?,'%')) escape '' or lower(p1_0.content) like lower(concat('%',?,'%')) escape '') order by p1_0.id desc limit ?`



<br>

## 📝 주의사항
<br> 실제 @Query기반  JPQL과 , QueryDSL을 적용한 코드  쿼리 시간을 측정해보았습니다.
측정 환경은 local에서 스웨거로 4-5개의 글을 만든 뒤 , 적용한 메소드를 사용하는 api를 호출하여 
Spring Log4jdb를 이용해 측정하였습니다.

* 변화가 적용된 메소드(findRecentPart, searchPart)
* 위 메소드는 각각 게시글 목록 조회(무한스크롤) , 파트 게시글 검색(무한스크롤) api에 사용되며, Spring Log4jdb 사용시 아래처럼 쿼리 실행 시간이 보입니다.
<img width="930" height="215" alt="스크린샷 2025-11-12 오후 6 36 41" src="https://github.com/user-attachments/assets/416faea0-461d-4982-924c-8d3306d213f0" />

결론적으로는 첫 번째 api, 게시글 목록 조회에 있어서 JPQL : 8ms, QueryDSL : 3ms 
두 번째 api 파트 게시글 검색에 있어서는 JPQL :  3ms , QueryDSL : 1ms 이 소요되어 
QueryDSL이 조금 더 빠름을 알 수 있습니다. 

이유를 찾아본 결과 QueryDSL은 미리 생성된 QClass 기반 직렬화로 오버헤드가 없지만, JPQL은 런타임에 문자열을 파싱하기 때문에 시간이 조금 더 소요된다고 합니다.

사실 정확한 테스트라고 보기 어렵습니다
1. 실제 환경이 아닌점 
2. DSL을 적용한 메소드가 2개밖에 없는점
3. 조회하는 글의 수가 현저히 적었던 점

팀원분들은 쿼리속도 측정 방식에 대하여 어떻게 생각하시는지도 여쭤보고 싶습니다. (뭘로 , 환경제어는 어떻게) 
Jmeter의 사용도 고려했으나,  JPQL → QueryDSL 교체가 쿼리 자체를 얼마나 줄였나/빨라졌나를 우선 검증에는  Spring Log4jdbc가 적합하다고 판단했습니다!



## ✅ 체크리스트

- [x] 리뷰어 설정
- [x] Assignee 설정
- [x] Label 설정
- [x] 제목 양식 맞췄나요? (ex. [WTH-01] PR 템플릿 수정)
- [x] 변경 사항에 대한 테스트


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 포스트 제목·내용 기반 키워드 검색 기능 추가
  * 최신 포스트 조회(부분 조회) 기능 추가
  * 파라미터 기반 필터링(파트, 카테고리, 회차 등) 및 페이지네이션으로 효율적 데이터 로딩 지원

* **테스트**
  * 검색 및 최신 조회 동작을 검증하는 저장소 단위 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->