### PR TITLE
[WTH-68] 출석 dto에 출석코드 추가

### DIFF
--- a/src/main/java/leets/weeth/domain/attendance/application/dto/AttendanceDTO.java
+++ b/src/main/java/leets/weeth/domain/attendance/application/dto/AttendanceDTO.java
@@ -1,5 +1,6 @@
 package leets.weeth.domain.attendance.application.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import leets.weeth.domain.attendance.domain.entity.enums.Status;
@@ -13,6 +14,8 @@ public class AttendanceDTO {
             Integer attendanceRate,
             String title,
             Status status,
+            @Schema(description = "어드민인 경우 출석 코드 노출")
+            Integer code,
             LocalDateTime start,
             LocalDateTime end,
             String location

--- a/src/main/java/leets/weeth/domain/attendance/application/mapper/AttendanceMapper.java
+++ b/src/main/java/leets/weeth/domain/attendance/application/mapper/AttendanceMapper.java
@@ -14,11 +14,23 @@ public interface AttendanceMapper {
             @Mapping(target = "attendanceRate", source = "user.attendanceRate"),
             @Mapping(target = "title", source = "attendance.meeting.title"),
             @Mapping(target = "status", source = "attendance.status"),
+            @Mapping(target = "code", ignore = true),
             @Mapping(target = "start", source = "attendance.meeting.start"),
             @Mapping(target = "end", source = "attendance.meeting.end"),
             @Mapping(target = "location", source = "attendance.meeting.location"),
     })
     AttendanceDTO.Main toMainDto(User user, Attendance attendance);
+
+    @Mappings({
+            @Mapping(target = "attendanceRate", source = "user.attendanceRate"),
+            @Mapping(target = "title", source = "attendance.meeting.title"),
+            @Mapping(target = "status", source = "attendance.status"),
+            @Mapping(target = "code", source = "attendance.meeting.code"),
+            @Mapping(target = "start", source = "attendance.meeting.start"),
+            @Mapping(target = "end", source = "attendance.meeting.end"),
+            @Mapping(target = "location", source = "attendance.meeting.location"),
+    })
+    AttendanceDTO.Main toAdminResponse(User user, Attendance attendance);
 
     @Mappings({
             @Mapping(target = "attendances", source = "attendances"),

--- a/src/main/java/leets/weeth/domain/attendance/application/usecase/AttendanceUseCaseImpl.java
+++ b/src/main/java/leets/weeth/domain/attendance/application/usecase/AttendanceUseCaseImpl.java
@@ -13,6 +13,7 @@ import leets.weeth.domain.schedule.domain.entity.Meeting;
 import leets.weeth.domain.schedule.domain.service.MeetingGetService;
 import leets.weeth.domain.user.domain.entity.Cardinal;
 import leets.weeth.domain.user.domain.entity.User;
+import leets.weeth.domain.user.domain.entity.enums.Role;
 import leets.weeth.domain.user.domain.service.UserCardinalGetService;
 import leets.weeth.domain.user.domain.service.UserGetService;
 import lombok.RequiredArgsConstructor;
@@ -65,6 +66,10 @@ public class AttendanceUseCaseImpl implements AttendanceUseCase {
                         && attendance.getMeeting().getEnd().toLocalDate().isEqual(LocalDate.now()))
                 .findAny()
                 .orElse(null);
+
+        if (Role.ADMIN == user.getRole()) {
+            return mapper.toAdminResponse(user, todayMeeting);
+        }
 
         return mapper.toMainDto(user, todayMeeting);
     }

--- a/src/test/java/leets/weeth/domain/attendance/test/fixture/AttendanceTestFixture.java
+++ b/src/test/java/leets/weeth/domain/attendance/test/fixture/AttendanceTestFixture.java
@@ -10,6 +10,7 @@ import leets.weeth.domain.schedule.domain.entity.Meeting;
 import leets.weeth.domain.user.domain.entity.User;
 import leets.weeth.domain.user.domain.entity.enums.Department;
 import leets.weeth.domain.user.domain.entity.enums.Position;
+import leets.weeth.domain.user.domain.entity.enums.Role;
 import leets.weeth.domain.user.domain.entity.enums.Status;
 
 public class AttendanceTestFixture {
@@ -19,6 +20,29 @@ public class AttendanceTestFixture {
 	//todo : 추후 User Fixture 활용 예정
 	public static User createActiveUser(String name) {
 		return User.builder().name(name).status(Status.ACTIVE).build();
+	}
+
+	public static User createAdminUser(String name) {
+		return User.builder().name(name).status(Status.ACTIVE).role(Role.ADMIN).build();
+	}
+
+	public static User createAdminUserWithAttendances(String name, List<Meeting> meetings) {
+		User user = createAdminUser(name);
+
+		if (user.getAttendances() == null) {
+			try {
+				java.lang.reflect.Field f = user.getClass().getDeclaredField("attendances");
+				f.setAccessible(true);
+				f.set(user, new java.util.ArrayList<>());
+			} catch (Exception ignore) {}
+		}
+		if (meetings != null) {
+			for (Meeting meeting : meetings) {
+				Attendance attendance = createAttendance(meeting, user);
+				user.add(attendance);
+			}
+		}
+		return user;
 	}
 
 	//todo : 추후 User Fixture 활용 예정


### PR DESCRIPTION
# 📌 PR 내용
- 출석 코드가 출석 페이지에서도 볼수 있게 됨에 따라 유저 권한을 확인해서 dto에 담아줄 수 있게 했습니다


<br>

## 🔍 PR 세부사항
- 코드 스타일은 정기모임에서 가져오는 부분과 통일했습니다.
- mapper의 동작만 검증했습니다. 추후에 통합 테스트가 필요해보이네용

<br>

## 📸 관련 스크린샷

<img width="1240" height="751" alt="image" src="https://github.com/user-attachments/assets/22ac4f0d-f3f4-45ec-a73e-4a296b0d0764" />

<br>

## 📝 주의사항

<br>

## ✅ 체크리스트

- [x] 리뷰어 설정
- [x] Assignee 설정
- [x] Label 설정
- [x] 제목 양식 맞췄나요? (ex. [WTH-01] PR 템플릿 수정)
- [x] 변경 사항에 대한 테스트


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 관리자 사용자에게 출석 코드 노출 기능 추가
  * 사용자 역할에 따른 차별화된 출석 정보 조회 기능 구현

* **Tests**
  * 일반 사용자의 출석 정보 조회 테스트 추가
  * 관리자의 출석 코드 포함 조회 테스트 추가
  * 관리자 사용자 생성 테스트 유틸리티 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->