### PR TITLE
[WTH-73] Apple private key 경로 환경변수 적용

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -34,7 +34,7 @@ auth:
       redirect_uri: ${APPLE_REDIRECT_URI}
       token_uri: https://appleid.apple.com/auth/token
       keys_uri: https://appleid.apple.com/auth/keys
-      private_key_path: AuthKey_5JL5Z7K6J7.p8
+      private_key_path: ${APPLE_PRIVATE_KEY_PATH}
       # 허용할 audience 목록 (웹 + Leenk 앱), 쉼표로 구분
       allowed_audiences: ${APPLE_CLIENT_ID},${APPLE_ALLOWED_AUDIENCES}
   jwt:


### PR DESCRIPTION
# 📌 PR 내용
- Apple private key 경로 환경변수 적용
<br>

## 🔍 PR 세부사항
- dev 환경에서 애플 client secret이 생성에 실패하는 문제가 있었습니다
  - 원인 : 기존 구현이 private key를 classpath에서만 읽도록 고정되어 있어 Docker 환경에서 .p8 파일을 찾지 못함
- private key 경로를 APPLE_PRIVATE_KEY_PATH 환경변수 기반으로 읽도록 수정
<br>

## 📸 관련 스크린샷

<br>

## 📝 주의사항

<br>

## ✅ 체크리스트

- [ ] 리뷰어 설정
- [ ] Assignee 설정
- [x] Label 설정
- [ ] 제목 양식 맞췄나요? (ex. [WTH-01] PR 템플릿 수정)
- [ ] 변경 사항에 대한 테스트


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * Apple 인증 설정을 개선했습니다. 개인 키 경로 설정이 환경 변수 기반으로 변경되어 배포 환경별 설정 관리가 더욱 유연해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->